### PR TITLE
add command for list exps

### DIFF
--- a/cmd/chaosd/ctl/command/list_command.go
+++ b/cmd/chaosd/ctl/command/list_command.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pingcap/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func NewListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list all the attack experiments",
+		Run:   listExpFunc,
+	}
+
+	return cmd
+}
+
+func listExpFunc(cmd *cobra.Command, args []string) {
+	chaos := mustChaosdFromCmd(cmd, &conf)
+	exps, err := chaos.Exp().List(context.Background())
+	if err != nil {
+		log.Error("failed to list experiments", zap.Error(err))
+		return
+	}
+
+	for _, exp := range exps {
+		fmt.Println(exp)
+	}
+}

--- a/cmd/chaosd/ctl/ctl.go
+++ b/cmd/chaosd/ctl/ctl.go
@@ -31,6 +31,7 @@ func init() {
 		command.NewAttackCommand(),
 		command.NewRecoverCommand(),
 		command.NewSearchCommand(),
+		command.NewListCommand(),
 	)
 }
 

--- a/pkg/core/experiment.go
+++ b/pkg/core/experiment.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 )
 
@@ -53,4 +54,9 @@ type Experiment struct {
 	Kind           string `json:"kind"`
 	Action         string `json:"action"`
 	RecoverCommand string `json:"recover_command"`
+}
+
+func (e *Experiment) String() string {
+	expBytes, _ := json.Marshal(e)
+	return string(expBytes)
 }

--- a/pkg/server/chaosd/server.go
+++ b/pkg/server/chaosd/server.go
@@ -46,3 +46,7 @@ func NewServer(
 		svr:          svr,
 	}
 }
+
+func (s *Server) Exp() core.ExperimentStore {
+	return s.exp
+}


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

users may forget to save the uid after doing attack, need to list all the experiments