### PR TITLE
fixed stress,process ACTION empty

### DIFF
--- a/cmd/chaosd/ctl/command/process_command.go
+++ b/cmd/chaosd/ctl/command/process_command.go
@@ -71,7 +71,7 @@ func processKillCommandFunc(cmd *cobra.Command, args []string) {
 
 func processStopCommandFunc(cmd *cobra.Command, args []string) {
 	pFlag.Signal = int(syscall.SIGSTOP)
-	pFlag.Action= core.ProcessStopAction
+	pFlag.Action = core.ProcessStopAction
 	processAttackF(cmd, &pFlag)
 }
 

--- a/cmd/chaosd/ctl/command/process_command.go
+++ b/cmd/chaosd/ctl/command/process_command.go
@@ -65,11 +65,13 @@ func NewProcessStopCommand() *cobra.Command {
 }
 
 func processKillCommandFunc(cmd *cobra.Command, args []string) {
+	pFlag.Action = core.ProcessKillAction
 	processAttackF(cmd, &pFlag)
 }
 
 func processStopCommandFunc(cmd *cobra.Command, args []string) {
 	pFlag.Signal = int(syscall.SIGSTOP)
+	pFlag.Action= core.ProcessStopAction
 	processAttackF(cmd, &pFlag)
 }
 

--- a/pkg/server/chaosd/stress_attack.go
+++ b/pkg/server/chaosd/stress_attack.go
@@ -37,6 +37,7 @@ func (s *Server) StressAttack(attack *core.StressCommand) (string, error) {
 		Uid:            uid,
 		Status:         core.Created,
 		Kind:           core.StressAttack,
+		Action:         attack.Action,
 		RecoverCommand: attack.String(),
 	}); err != nil {
 		return "", errors.WithStack(err)


### PR DESCRIPTION
Signed-off-by: wuxiaohui <wuxiaohui94@126.com>
Fixed stress attack and process attack, ACTION is empty when use chaosd search -A