### PR TITLE
support create disk chaos and recover disk chaos in server mode

### DIFF
--- a/pkg/core/disk.go
+++ b/pkg/core/disk.go
@@ -22,10 +22,10 @@ const (
 )
 
 type DiskCommand struct {
-	Action          string
-	Size            uint64
-	Path            string
-	FillByFallocate bool
+	Action          string `json:"action"`
+	Size            uint64 `json:"size"`
+	Path            string `json:"path"`
+	FillByFallocate bool   `json:"fill_by_fallocate"`
 }
 
 func (d *DiskCommand) Validate() error {

--- a/pkg/server/chaosd/disk.go
+++ b/pkg/server/chaosd/disk.go
@@ -167,3 +167,34 @@ func (s *Server) DiskFill(fill *core.DiskCommand) (uid string, err error) {
 
 	return uid, err
 }
+
+const RecoverDisk = "truncate --size=-%sM %s"
+
+func (s *Server) RecoverDiskAttack(uid string, attack *core.DiskCommand) error {
+	switch attack.Action {
+	case core.DiskFillAction:
+		cmd := exec.Command("bash", "-c",
+			fmt.Sprintf(RecoverDisk, strconv.FormatUint(attack.Size, 10), attack.Path))
+		output, err := cmd.CombinedOutput()
+
+		if err != nil {
+			log.Error(string(output), zap.Error(err))
+		} else {
+			log.Info(string(output))
+		}
+		return err
+	case DDWritePayloadCommand:
+		cmd := exec.Command("bash", "-c",
+			fmt.Sprintf(RecoverDisk, strconv.FormatUint(attack.Size, 10), attack.Path))
+		output, err := cmd.CombinedOutput()
+
+		if err != nil {
+			log.Error(string(output), zap.Error(err))
+		} else {
+			log.Info(string(output))
+		}
+		return err
+	default:
+		return nil
+	}
+}

--- a/pkg/server/chaosd/disk.go
+++ b/pkg/server/chaosd/disk.go
@@ -168,33 +168,10 @@ func (s *Server) DiskFill(fill *core.DiskCommand) (uid string, err error) {
 	return uid, err
 }
 
-const RecoverDisk = "truncate --size=-%sM %s"
-
 func (s *Server) RecoverDiskAttack(uid string, attack *core.DiskCommand) error {
-	switch attack.Action {
-	case core.DiskFillAction:
-		cmd := exec.Command("bash", "-c",
-			fmt.Sprintf(RecoverDisk, strconv.FormatUint(attack.Size, 10), attack.Path))
-		output, err := cmd.CombinedOutput()
-
-		if err != nil {
-			log.Error(string(output), zap.Error(err))
-		} else {
-			log.Info(string(output))
-		}
-		return err
-	case DDWritePayloadCommand:
-		cmd := exec.Command("bash", "-c",
-			fmt.Sprintf(RecoverDisk, strconv.FormatUint(attack.Size, 10), attack.Path))
-		output, err := cmd.CombinedOutput()
-
-		if err != nil {
-			log.Error(string(output), zap.Error(err))
-		} else {
-			log.Info(string(output))
-		}
-		return err
-	default:
-		return nil
+	log.Info("Recover disk attack will do nothing, because delete | truncate data is too dangerous.")
+	if err := s.exp.Update(context.Background(), uid, core.Destroyed, "", attack.String()); err != nil {
+		return errors.WithStack(err)
 	}
+	return nil
 }

--- a/pkg/server/utils/recover.go
+++ b/pkg/server/utils/recover.go
@@ -70,6 +70,15 @@ func RecoverExp(expStore core.ExperimentStore, chaos *chaosd.Server, uid string)
 		if err := chaos.RecoverStressAttack(uid, scmd); err != nil {
 			return err
 		}
+	case core.DiskAttack:
+		scmd := &core.DiskCommand{}
+		if err := json.Unmarshal([]byte(exp.RecoverCommand), scmd); err != nil {
+			return err
+		}
+
+		if err := chaos.RecoverDiskAttack(uid, scmd); err != nil {
+			return err
+		}
 	default:
 		return errors.Errorf("chaos experiment kind %s not found", exp.Kind)
 	}


### PR DESCRIPTION
Signed-off-by: andrewmatilde <davis6813585853062@outlook.com>

create attack:
```
curl 0.0.0.0:31767/api/attack/disk -H "Content-Type: application/json" -d '{"action":"fill","size":1024,"path":"temp"}'
```
recover attack:
```
curl -X DELETE 0.0.0.0:31767/api/attack/603a1bba-474f-4a60-b7a1-442c7bdc5dc6
```