### PR TITLE
Gitpodifyed the repository

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-full
+RUN sudo apt-get update && \
+	sudo apt-get install -y ipset stress-ng

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,15 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: make build
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+vscode:
+  extensions:
+    - golang.go
+    - ms-azuretools.vscode-docker

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # chaosd
 
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/chaos-mesh/chaosd)
+
 chaosd is an easy-to-use Chaos Engineering tool used to inject failures to a physical node. Currently, two modes are supported:
 
 - **Command mode** - Using chaosd as a command-line tool. Supported failure types are:
@@ -362,3 +364,10 @@ Sample usage:
 ```bash
 $ curl -X DELETE "127.0.0.1:31767/api/attack/20df86e9-96e7-47db-88ce-dd31bc70c4f0"
 ```
+
+
+## Development
+
+You can develop chaosd directly from your browser in a pre-configured development environment in the cloud:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/chaos-mesh/chaosd)


### PR DESCRIPTION
Hi chaos-mesh team! 👋

here is a PR that fully-automates the dev setup of chaosd with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/chaos-mesh/chaosd)

<img width="1659" alt="Screen Shot 2021-05-05 at 17 48 20" src="https://user-images.githubusercontent.com/377752/117170457-54a48800-adca-11eb-811f-0a4a9d8bf858.png">

### What it does

* Comes with all chaosd dependencies pre-installed (including Go, iptables, ipset, stress_ng etc.)
* Runs `make build` ahead-of-time so you don't need to wait
* Gives anyone immediate access to the pre-compiled chaosd CLI, and allows to easily edit & rebuild the code

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).

And I'm looking forward to your feedback on this PR! 🚀

Signed-off-by: Jan Koehnlein <jan@gitpod.io>