### PR TITLE
JVM attack: support use byteman rule file

### DIFF
--- a/cmd/attack/jvm.go
+++ b/cmd/attack/jvm.go
@@ -78,6 +78,7 @@ func NewJVMSubmitCommand(dep fx.Option, options *core.JVMCommand) *cobra.Command
 		NewJVMExceptionCommand(dep, options),
 		NewJVMStressCommand(dep, options),
 		NewJVMGCCommand(dep, options),
+		NewJVMRuleFileCommand(dep, options),
 	)
 
 	return cmd
@@ -159,6 +160,21 @@ func NewJVMGCCommand(dep fx.Option, options *core.JVMCommand) *cobra.Command {
 			utils.FxNewAppWithoutLog(dep, fx.Invoke(jvmCommandFunc)).Run()
 		},
 	}
+
+	return cmd
+}
+
+func NewJVMRuleFileCommand(dep fx.Option, options *core.JVMCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rule-file [options]",
+		Short: "inject fault with configured byteman rule file",
+		Run: func(*cobra.Command, []string) {
+			options.Action = core.JVMRuleFileAction
+			utils.FxNewAppWithoutLog(dep, fx.Invoke(jvmCommandFunc)).Run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.RuleFile, "path", "p", "", "the path of configured byteman rule file")
 
 	return cmd
 }

--- a/pkg/core/jvm.go
+++ b/pkg/core/jvm.go
@@ -31,6 +31,7 @@ const (
 	JVMReturnAction    = "return"
 	JVMStressAction    = "stress"
 	JVMGCAction        = "gc"
+	JVMRuleFileAction  = "rule_file"
 )
 
 type JVMCommand struct {
@@ -80,6 +81,12 @@ type JVMCommand struct {
 	StressValueName string
 
 	StressValue int
+
+	// btm rule file path
+	RuleFile string
+
+	// RuleData used to save the rule file's data, will use it when recover
+	RuleData []byte
 }
 
 func (j *JVMCommand) Validate() error {
@@ -107,6 +114,10 @@ func (j *JVMCommand) Validate() error {
 
 			if len(j.Method) == 0 {
 				return errors.New("method not provided")
+			}
+		case JVMRuleFileAction:
+			if len(j.RuleFile) == 0 {
+				return errors.New("rule file not provided")
 			}
 		case "":
 			return errors.New("action not provided, action can be 'latency', 'exception', 'return', 'stress' or 'gc'")


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

support use byyeman rule file directly.

```bash
./bin/chaosd attack jvm rule-file --help
JVM attack related commands

Usage:
  chaosd attack jvm [command]

Available Commands:
  install     install agent to Java process
  submit      submit rules for byteman agent

Flags:
  -h, --help   help for jvm

Global Flags:
      --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'

Use "chaosd attack jvm [command] --help" for more information about a command.
```