### PR TITLE
package the chaosd and tools into one compressed file

### DIFF
--- a/.github/workflows/release_latest.yml
+++ b/.github/workflows/release_latest.yml
@@ -27,4 +27,10 @@ jobs:
         run: make build
       - name: Upload files
         run: |
-          aws s3 cp bin/chaosd ${{ secrets.AWS_BUCKET_NAME }}/latest/chaosd
+          curl -fsSL -o chaosd-tools.tar.gz https://mirrors.chaos-mesh.org/chaosd-tools.tar.gz
+          tar zxvf chaosd-tools.tar.gz
+          mkdir chaosd-latest-linux-amd64
+          mv bin/chaosd chaosd-latest-linux-amd64/
+          mv chaosd-tools chaosd-latest-linux-amd64/tools
+          tar czvf chaosd-latest-linux-amd64.tar.gz chaosd-latest-linux-amd64
+          aws s3 cp chaosd-latest-linux-amd64.tar.gz ${{ secrets.AWS_BUCKET_NAME }}/chaosd-latest-linux-amd64.tar.gz

--- a/.github/workflows/release_latest.yml
+++ b/.github/workflows/release_latest.yml
@@ -27,10 +27,20 @@ jobs:
         run: make build
       - name: Upload files
         run: |
-          curl -fsSL -o chaosd-tools.tar.gz https://mirrors.chaos-mesh.org/chaosd-tools.tar.gz
-          tar zxvf chaosd-tools.tar.gz
+
+          # download tools
+          curl -fsSL -o byteman.tar.gz https://mirrors.chaos-mesh.org/latest/byteman.tar.gz
+          curl -fsSL -o stress-ng https://mirrors.chaos-mesh.org/latest/stress-ng
+          tar zxvf byteman.tar.gz
+          chmod +x ./stress-ng
+
+          # prepare package
           mkdir chaosd-latest-linux-amd64
+          mkdir chaosd-latest-linux-amd64/tools
           mv bin/chaosd chaosd-latest-linux-amd64/
-          mv chaosd-tools chaosd-latest-linux-amd64/tools
+          mv byteman chaosd-latest-linux-amd64/tools/
+          mv stress-ng chaosd-latest-linux-amd64/tools/
+
+          # upload package
           tar czvf chaosd-latest-linux-amd64.tar.gz chaosd-latest-linux-amd64
           aws s3 cp chaosd-latest-linux-amd64.tar.gz ${{ secrets.AWS_BUCKET_NAME }}/chaosd-latest-linux-amd64.tar.gz

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -27,11 +27,22 @@ jobs:
         run: make build
       - name: Upload files
         run: |
+
           GIT_TAG=${GITHUB_REF##*/}
-          curl -fsSL -o chaosd-tools.tar.gz https://mirrors.chaos-mesh.org/chaosd-tools.tar.gz
-          tar zxvf chaosd-tools.tar.gz
+
+          # download tools
+          curl -fsSL -o byteman.tar.gz https://mirrors.chaos-mesh.org/latest/byteman.tar.gz
+          curl -fsSL -o stress-ng https://mirrors.chaos-mesh.org/latest/stress-ng
+          tar zxvf byteman.tar.gz
+          chmod +x ./stress-ng
+
+          # prepare package
           mkdir chaosd-${GIT_TAG}-linux-amd64
+          mkdir chaosd-${GIT_TAG}-linux-amd64/tools
           mv bin/chaosd chaosd-${GIT_TAG}-linux-amd64/
-          mv chaosd-tools chaosd-${GIT_TAG}-linux-amd64/tools
+          mv byteman chaosd-${GIT_TAG}-linux-amd64/tools/
+          mv stress-ng chaosd-${GIT_TAG}-linux-amd64/tools/
+
+          # upload package
           tar czvf chaosd-${GIT_TAG}-linux-amd64.tar.gz chaosd-${GIT_TAG}-linux-amd64
           aws s3 cp chaosd-${GIT_TAG}-linux-amd64.tar.gz ${{ secrets.AWS_BUCKET_NAME }}/chaosd-${GIT_TAG}-linux-amd64.tar.gz

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -28,4 +28,10 @@ jobs:
       - name: Upload files
         run: |
           GIT_TAG=${GITHUB_REF##*/}
-          aws s3 cp bin/chaosd ${{ secrets.AWS_BUCKET_NAME }}/${GIT_TAG}/chaosd
+          curl -fsSL -o chaosd-tools.tar.gz https://mirrors.chaos-mesh.org/chaosd-tools.tar.gz
+          tar zxvf chaosd-tools.tar.gz
+          mkdir chaosd-latest-linux-amd64
+          mv bin/chaosd chaosd-latest-linux-amd64/
+          mv chaosd-tools chaosd-latest-linux-amd64/tools
+          tar czvf chaosd-latest-linux-amd64.tar.gz chaosd-latest-linux-amd64
+          aws s3 cp chaosd-latest-linux-amd64.tar.gz ${{ secrets.AWS_BUCKET_NAME }}/chaosd-${GIT_TAG}-linux-amd64.tar.gz

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -30,8 +30,8 @@ jobs:
           GIT_TAG=${GITHUB_REF##*/}
           curl -fsSL -o chaosd-tools.tar.gz https://mirrors.chaos-mesh.org/chaosd-tools.tar.gz
           tar zxvf chaosd-tools.tar.gz
-          mkdir chaosd-latest-linux-amd64
-          mv bin/chaosd chaosd-latest-linux-amd64/
-          mv chaosd-tools chaosd-latest-linux-amd64/tools
-          tar czvf chaosd-latest-linux-amd64.tar.gz chaosd-latest-linux-amd64
-          aws s3 cp chaosd-latest-linux-amd64.tar.gz ${{ secrets.AWS_BUCKET_NAME }}/chaosd-${GIT_TAG}-linux-amd64.tar.gz
+          mkdir chaosd-${GIT_TAG}-linux-amd64
+          mv bin/chaosd chaosd-${GIT_TAG}-linux-amd64/
+          mv chaosd-tools chaosd-${GIT_TAG}-linux-amd64/tools
+          tar czvf chaosd-${GIT_TAG}-linux-amd64.tar.gz chaosd-${GIT_TAG}-linux-amd64
+          aws s3 cp chaosd-${GIT_TAG}-linux-amd64.tar.gz ${{ secrets.AWS_BUCKET_NAME }}/chaosd-${GIT_TAG}-linux-amd64.tar.gz

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can either build directly from the source or download the binary to finish t
     curl -fsSL -o chaosd-v1.0.0-linux-amd64.tar.gz https://mirrors.chaos-mesh.org/chaosd-v1.0.0-linux-amd64.tar.gz
     ```
 
-    Then uncompress the archived file, and you can go to the folder and execute chaosd：
+    Then uncompress the archived file, and you can go into the folder and execute chaosd：
 
     ```bash
     tar zxvf chaosd-latest-linux-amd64.tar.gz && cd chaosd-latest-linux-amd64

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Before deploying chaosd, make sure the following items have been installed:
 * [tc](https://linux.die.net/man/8/tc)
 * [ipset](https://linux.die.net/man/8/ipset)
 * [iptables](https://linux.die.net/man/8/iptables)
-* [stress-ng](https://wiki.ubuntu.com/Kernel/Reference/stress-ng)
+* [stress-ng](https://wiki.ubuntu.com/Kernel/Reference/stress-ng) (required when install chaosd by building from source code)
+* [byteman](https://github.com/chaos-mesh/byteman)(required when install chaosd by building from source code)
 
 ## Install
 
@@ -37,7 +38,7 @@ You can either build directly from the source or download the binary to finish t
 
     ```bash
     make chaosd
-    chmod +x chaosd && mv chaosd /usr/local/bin/chaosd
+    mv chaosd /usr/local/bin/chaosd
     ```
 
 - Download binary
@@ -45,19 +46,19 @@ You can either build directly from the source or download the binary to finish t
     Download the latest unstable version by executing the command below:
 
     ```bash
-    curl -fsSL -o chaosd https://mirrors.chaos-mesh.org/latest/chaosd
+    curl -fsSL -o chaosd-latest-linux-amd64.tar.gz https://mirrors.chaos-mesh.org/chaosd-latest-linux-amd64.tar.gz
     ```
 
-    If you want to download the release version, you can replace the `latest` in the above command with the version number. For example, download `v0.9.0` by executing the command below:
+    If you want to download the release version, you can replace the `latest` in the above command with the version number. For example, download `v1.0.0` by executing the command below:
 
     ```bash
-    curl -fsSL -o chaosd https://mirrors.chaos-mesh.org/v0.9.0/chaosd
+    curl -fsSL -o chaosd-v1.0.0-linux-amd64.tar.gz https://mirrors.chaos-mesh.org/chaosd-v1.0.0-linux-amd64.tar.gz
     ```
 
-    Then add executable permissions to the chaosd and move it to path `/usr/local/bin`:
+    Then uncompress the archived file, and you can go to the folder and execute chaosd：
 
     ```bash
-    chmod +x chaosd && mv chaosd /usr/local/bin/chaosd
+    tar zxvf chaosd-latest-linux-amd64.tar.gz && cd chaosd-latest-linux-amd64
     ```
 
 ## Usages

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,7 +50,7 @@ func init() {
 		version.NewVersionCommand(),
 	)
 
-	utils.SetRuntimeEnv()
+	_ = utils.SetRuntimeEnv()
 }
 
 func setLogLevel() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,6 +49,8 @@ func init() {
 		search.NewSearchCommand(),
 		version.NewVersionCommand(),
 	)
+
+	utils.SetRuntimeEnv()
 }
 
 func setLogLevel() {

--- a/pkg/server/chaosd/jvm.go
+++ b/pkg/server/chaosd/jvm.go
@@ -145,8 +145,6 @@ func (j jvmAttack) submit(attack *core.JVMCommand) error {
 
 	log.Info("create btm file", zap.String("file", tmpfile.Name()))
 
-	defer os.Remove(tmpfile.Name()) // clean up
-
 	if _, err := tmpfile.Write(buf.Bytes()); err != nil {
 		return err
 	}

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Chaos Mesh Authors.
+// Copyright 2021 Chaos Mesh Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,22 +19,27 @@ import (
 	"path/filepath"
 )
 
-func SetRuntimeEnv() {
+func SetRuntimeEnv() error {
 	wd, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
-		return
+		return err
 	}
 
 	_, err = os.Stat(fmt.Sprintf("%s/tools", wd))
 	if os.IsNotExist(err) {
-		return
+		return err
 	}
 
 	path := os.Getenv("PATH")
 	bytemanHome := fmt.Sprintf("%s/tools/byteman", wd)
-	os.Setenv("BYTEMAN_HOME", bytemanHome)
-	os.Setenv("PATH", fmt.Sprintf("%s/tools:%s/bin:%s", wd, bytemanHome, path))
+	err = os.Setenv("BYTEMAN_HOME", bytemanHome)
+	if err != nil {
+		return err
+	}
+	err = os.Setenv("PATH", fmt.Sprintf("%s/tools:%s/bin:%s", wd, bytemanHome, path))
+	if err != nil {
+		return err
+	}
 
-	//fmt.Println("BYTEMAN_HOME:", os.Getenv("BYTEMAN_HOME"))
-	//fmt.Println("PATH:", os.Getenv("PATH"))
+	return nil
 }

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -16,15 +16,16 @@ package utils
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func SetRuntimeEnv() {
-	wd, err := os.Getwd()
+	wd, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
 		return
 	}
 
-	_, err = os.Stat("./tools")
+	_, err = os.Stat(fmt.Sprintf("%s/tools", wd))
 	if os.IsNotExist(err) {
 		return
 	}

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+func SetRuntimeEnv() {
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	_, err = os.Stat("./tools")
+	if os.IsNotExist(err) {
+		return
+	}
+
+	path := os.Getenv("PATH")
+	bytemanHome := fmt.Sprintf("%s/tools/byteman", wd)
+	os.Setenv("BYTEMAN_HOME", bytemanHome)
+	os.Setenv("PATH", fmt.Sprintf("%s/tools:%s/bin:%s", wd, bytemanHome, path))
+
+	//fmt.Println("BYTEMAN_HOME:", os.Getenv("BYTEMAN_HOME"))
+	//fmt.Println("PATH:", os.Getenv("PATH"))
+}


### PR DESCRIPTION
users can download this compressed file, and run chaosd directly, don't need to install stress-ng and byteman.

the dir tree looks like:

  - chaosd
  - tools
      - byteman
      - stress-ng

