### PR TITLE
Fix bug and implement recover for disk chaos

### DIFF
--- a/cmd/attack/disk.go
+++ b/cmd/attack/disk.go
@@ -127,6 +127,9 @@ func NewDiskFillCommand(dep fx.Option, options *core.DiskOption) *cobra.Command 
 		"'percent' how many percent data of disk will fill in the file path")
 	cmd.Flags().BoolVarP(&options.FillByFallocate, "fallocate", "f", true, "fill disk by fallocate instead of dd")
 	cmd.Flags().BoolVarP(&options.DestroyFile, "destroy", "d", false, "destroy file after filled in or allocated")
+	cmd.Flags().BoolVarP(&options.ForceOverwrite, "force_overwrite", "o", false,
+		"'force_overwrite' is a flag means overwrite a file is valid now."+
+			"'force_overwrite' only works when `fallocate` is false.")
 	return cmd
 }
 

--- a/cmd/attack/disk.go
+++ b/cmd/attack/disk.go
@@ -127,9 +127,6 @@ func NewDiskFillCommand(dep fx.Option, options *core.DiskOption) *cobra.Command 
 		"'percent' how many percent data of disk will fill in the file path")
 	cmd.Flags().BoolVarP(&options.FillByFallocate, "fallocate", "f", true, "fill disk by fallocate instead of dd")
 	cmd.Flags().BoolVarP(&options.DestroyFile, "destroy", "d", false, "destroy file after filled in or allocated")
-	cmd.Flags().BoolVarP(&options.ForceOverwrite, "force_overwrite", "o", false,
-		"'force_overwrite' is a flag means overwrite a file is valid now."+
-			"'force_overwrite' only works when `fallocate` is false.")
 	return cmd
 }
 

--- a/cmd/attack/disk.go
+++ b/cmd/attack/disk.go
@@ -126,7 +126,6 @@ func NewDiskFillCommand(dep fx.Option, options *core.DiskOption) *cobra.Command 
 	cmd.Flags().StringVarP(&options.Percent, "percent", "c", "",
 		"'percent' how many percent data of disk will fill in the file path")
 	cmd.Flags().BoolVarP(&options.FillByFallocate, "fallocate", "f", true, "fill disk by fallocate instead of dd")
-	cmd.Flags().BoolVarP(&options.DestroyFile, "destroy", "d", false, "destroy file after filled in or allocated")
 	return cmd
 }
 

--- a/cmd/attack/disk_test.go
+++ b/cmd/attack/disk_test.go
@@ -47,7 +47,7 @@ func TestServer_DiskFill(t *testing.T) {
 							Kind:   core.DiskAttack,
 						},
 						Size:              "1024M",
-						Path:              "temp",
+						Path:              "./temp",
 						FillByFallocate:   true,
 						PayloadProcessNum: 1,
 					},
@@ -60,7 +60,7 @@ func TestServer_DiskFill(t *testing.T) {
 							Kind:   core.DiskAttack,
 						},
 						Size:              "24MB",
-						Path:              "temp",
+						Path:              "./temp",
 						FillByFallocate:   false,
 						PayloadProcessNum: 1,
 					},
@@ -71,15 +71,7 @@ func TestServer_DiskFill(t *testing.T) {
 		fx.Invoke(func(s *chaosd.Server, tests []diskTest) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					f, err := os.Create(tt.option.Path)
-					if err != nil {
-						t.Errorf("unexpected err %v when creating temp file", err)
-						return
-					}
-					if f != nil {
-						_ = f.Close()
-					}
-					_, err = s.ExecuteAttack(chaosd.DiskAttack, tt.option, core.CommandMode)
+					_, err := s.ExecuteAttack(chaosd.DiskAttack, tt.option, core.CommandMode)
 					if (err != nil) != tt.wantErr {
 						t.Errorf("DiskFill() error = %v, wantErr %v", err, tt.wantErr)
 						return
@@ -116,7 +108,7 @@ func TestServer_DiskPayload(t *testing.T) {
 							Kind:   core.DiskAttack,
 						},
 						Size:              "24M",
-						Path:              "temp",
+						Path:              "./temp",
 						PayloadProcessNum: 1,
 					},
 					wantErr: false,
@@ -128,7 +120,7 @@ func TestServer_DiskPayload(t *testing.T) {
 							Kind:   core.DiskAttack,
 						},
 						Size:              "24M",
-						Path:              "temp",
+						Path:              "./temp",
 						PayloadProcessNum: 1,
 					},
 					wantErr: false,
@@ -138,24 +130,20 @@ func TestServer_DiskPayload(t *testing.T) {
 		fx.Invoke(func(s *chaosd.Server, tests []diskTest) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					f, err := os.Create(tt.option.Path)
-					if err != nil {
-						t.Errorf("unexpected err %v when creating temp file", err)
-						return
-					}
-					if f != nil {
-						_ = f.Close()
-					}
-
-					_, err = s.ExecuteAttack(chaosd.DiskAttack, &core.DiskOption{
+					_, err := s.ExecuteAttack(chaosd.DiskAttack, &core.DiskOption{
 						CommonAttackConfig: core.CommonAttackConfig{
 							Action: core.DiskFillAction,
 							Kind:   core.DiskAttack,
 						},
-						Size:            tt.option.Size,
-						Path:            "temp",
-						FillByFallocate: true,
+						PayloadProcessNum: 1,
+						Size:              tt.option.Size,
+						Path:              "./temp",
+						FillByFallocate:   true,
 					}, core.CommandMode)
+					if err != nil {
+						t.Error(err)
+						return
+					}
 					_, err = s.ExecuteAttack(chaosd.DiskAttack, tt.option, core.CommandMode)
 					if (err != nil) != tt.wantErr {
 						t.Errorf("DiskPayload() error = %v, wantErr %v", err, tt.wantErr)
@@ -185,7 +173,6 @@ func writeArgsToDiskOption(args writeArgs) core.DiskOption {
 		Path:              args.Path,
 		Percent:           "",
 		FillByFallocate:   false,
-		DestroyFile:       false,
 		PayloadProcessNum: args.PayloadProcessNum,
 	}
 }
@@ -272,7 +259,6 @@ func readArgsToDiskOption(args readArgs) core.DiskOption {
 		Path:              args.Path,
 		Percent:           "",
 		FillByFallocate:   false,
-		DestroyFile:       false,
 		PayloadProcessNum: args.PayloadProcessNum,
 	}
 }

--- a/pkg/core/disk.go
+++ b/pkg/core/disk.go
@@ -38,7 +38,6 @@ type DiskOption struct {
 	PayloadProcessNum uint8  `json:"payload_process_num"`
 
 	FillByFallocate bool `json:"fill_by_fallocate"`
-	DestroyFile     bool `json:"destroy_file"`
 }
 
 var _ AttackConfig = &DiskOption{}
@@ -85,7 +84,7 @@ func (d *DiskOption) Validate() error {
 				return err
 			}
 		} else {
-			return fmt.Errorf("write into a existing file when not forcing overwrite")
+			return fmt.Errorf("fill into a existing file")
 		}
 	}
 

--- a/pkg/core/disk.go
+++ b/pkg/core/disk.go
@@ -84,7 +84,7 @@ func (d *DiskOption) Validate() error {
 				return err
 			}
 		} else {
-			return fmt.Errorf("fill into a existing file")
+			return fmt.Errorf("fill into an existing file")
 		}
 	}
 

--- a/pkg/core/disk.go
+++ b/pkg/core/disk.go
@@ -61,8 +61,8 @@ func (d *DiskOption) Validate() error {
 		}
 	}
 
-	if d.Action == DiskFillAction {
-		if d.FillByFallocate && byteSize == 0 {
+	if d.Action == DiskFillAction || d.Action == DiskWritePayloadAction {
+		if d.Action == DiskFillAction && d.FillByFallocate && byteSize == 0 {
 			return fmt.Errorf("fallocate not suppurt 0 size or 0 percent data, "+
 				"if you want allocate a 0 size file please set fallocate=false, DiskOption : %v", d)
 		}
@@ -84,7 +84,10 @@ func (d *DiskOption) Validate() error {
 				return err
 			}
 		} else {
-			return fmt.Errorf("fill into an existing file")
+			if d.Action == DiskFillAction {
+				return fmt.Errorf("fill into an existing file")
+			}
+			return fmt.Errorf("write into an existing file")
 		}
 	}
 

--- a/pkg/server/chaosd/disk.go
+++ b/pkg/server/chaosd/disk.go
@@ -151,6 +151,7 @@ func (diskAttack) diskPayload(payload *core.DiskOption) error {
 	return nil
 }
 
+// dd command with 'oflag=append conv=notrunc' will append new data in the file.
 const DDFillCommand = "dd if=/dev/zero of=%s bs=%s count=%s iflag=fullblock oflag=append conv=notrunc"
 const FallocateCommand = "fallocate -l %s %s"
 

--- a/pkg/utils/units.go
+++ b/pkg/utils/units.go
@@ -88,9 +88,17 @@ func SplitBytesByProcessNum(bytes uint64, processNum uint8) ([]DdArgBlock, error
 			bytes -= blockSize
 		}
 	}
-	ddArgBlocks = append(ddArgBlocks, DdArgBlock{
-		BlockSize: "1",
-		Count:     strconv.FormatUint(bytes, 10) + "c",
-	})
+
+	if bytes == 0 {
+		ddArgBlocks = append(ddArgBlocks, DdArgBlock{
+			Count:     "0",
+			BlockSize: "1M",
+		})
+	} else {
+		ddArgBlocks = append(ddArgBlocks, DdArgBlock{
+			Count:     "1",
+			BlockSize: strconv.FormatUint(bytes, 10) + "c",
+		})
+	}
 	return ddArgBlocks, nil
 }


### PR DESCRIPTION
Signed-off-by: Andrewmatilde <davis6813585853062@outlook.com>

Fix bugs in [SplitBytesByProcessNum](https://github.com/chaos-mesh/chaosd/blob/main/pkg/utils/units.go#L92) that put BlockSize and Count value into wrong place with exchange them.

Add make overwrite in disk fill invalid.
Add recover with remove filled file or wrote file.