### PR TITLE
some minor update

### DIFF
--- a/cmd/attack/network.go
+++ b/cmd/attack/network.go
@@ -152,7 +152,7 @@ func NetworkDuplicateCommand(dep fx.Option, options *core.NetworkCommand) *cobra
 		},
 	}
 
-	cmd.Flags().StringVar(&options.Percent, "percent", "1", "percentage of packets to corrupt (10 is 10%)")
+	cmd.Flags().StringVar(&options.Percent, "percent", "1", "percentage of packets to duplicate (10 is 10%)")
 	cmd.Flags().StringVarP(&options.Correlation, "correlation", "c", "0", "correlation is percentage (10 is 10%)")
 	cmd.Flags().StringVarP(&options.Device, "device", "d", "", "the network interface to impact")
 	cmd.Flags().StringVarP(&options.EgressPort, "egress-port", "e", "",

--- a/cmd/attack/stress.go
+++ b/cmd/attack/stress.go
@@ -53,6 +53,7 @@ func NewStressCPUCommand(dep fx.Option, options *core.StressCommand) *cobra.Comm
 		Short: "continuously stress CPU out",
 		Run: func(*cobra.Command, []string) {
 			options.Action = core.StressCPUAction
+			options.CompleteDefaults()
 			utils.FxNewAppWithoutLog(dep, fx.Invoke(stressAttackF)).Run()
 		},
 	}
@@ -70,11 +71,11 @@ func NewStressMemCommand(dep fx.Option, options *core.StressCommand) *cobra.Comm
 		Short: "continuously stress virtual memory out",
 		Run: func(*cobra.Command, []string) {
 			options.Action = core.StressMemAction
+			options.CompleteDefaults()
 			utils.FxNewAppWithoutLog(dep, fx.Invoke(stressAttackF)).Run()
 		},
 	}
 
-	cmd.Flags().IntVarP(&options.Workers, "workers", "w", 1, "Workers specifies N workers to apply the stressor.")
 	cmd.Flags().StringVarP(&options.Size, "size", "s", "", "Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB..")
 	cmd.Flags().StringSliceVarP(&options.Options, "options", "o", []string{}, "extend stress-ng options.")
 

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -51,7 +51,7 @@ func NewSearchCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&options.Status, "status", "s", "", "attack status, "+
 		"supported value: created, success, error, destroyed, revoked")
 	cmd.Flags().StringVarP(&options.Kind, "kind", "k", "", "attack kind, "+
-		"supported value: network, process")
+		"supported value: network, process, stress, disk, host, jvm")
 	cmd.Flags().Uint32VarP(&options.Offset, "offset", "o", 0, "starting to search attacks from offset")
 	cmd.Flags().Uint32VarP(&options.Limit, "limit", "l", 0, "limit the count of attacks")
 	cmd.Flags().BoolVar(&options.Asc, "asc", false, "order by CreateTime, "+

--- a/pkg/core/search.go
+++ b/pkg/core/search.go
@@ -33,10 +33,8 @@ func (s SearchCommand) Validate() error {
 	}
 
 	if len(s.Kind) > 0 {
-		switch s.Kind {
-		case NetworkAttack, ProcessAttack:
-			break
-		default:
+		attack := GetAttackByKind(s.Kind)
+		if attack == nil {
 			return errors.Errorf("type %s not supported", s.Kind)
 		}
 	}

--- a/pkg/core/stress.go
+++ b/pkg/core/stress.go
@@ -51,7 +51,6 @@ func (s *StressCommand) CompleteDefaults() {
 	if s.Workers == 0 {
 		s.Workers = 1
 	}
-
 }
 
 func (s StressCommand) RecoverData() string {

--- a/pkg/core/stress.go
+++ b/pkg/core/stress.go
@@ -47,6 +47,13 @@ func (s *StressCommand) Validate() error {
 	return nil
 }
 
+func (s *StressCommand) CompleteDefaults() {
+	if s.Workers == 0 {
+		s.Workers = 1
+	}
+
+}
+
 func (s StressCommand) RecoverData() string {
 	data, _ := json.Marshal(s)
 

--- a/pkg/server/chaosd/disk.go
+++ b/pkg/server/chaosd/disk.go
@@ -112,7 +112,7 @@ func (diskAttack) diskPayload(payload *core.DiskOption) error {
 	}
 	ddBlocks, err := utils.SplitBytesByProcessNum(byteSize, payload.PayloadProcessNum)
 	if err != nil {
-		log.Error(fmt.Sprintf("split size ,process num %d", payload.PayloadProcessNum), zap.Error(err))
+		log.Error(fmt.Sprintf("split size, process num %d", payload.PayloadProcessNum), zap.Error(err))
 		return err
 	}
 	if len(ddBlocks) == 0 {

--- a/test/integration_test/stress/run.sh
+++ b/test/integration_test/stress/run.sh
@@ -40,7 +40,7 @@ timeout 5s tail --pid=$PID -f /dev/null
 ps aux | grep stress-ng
 
 # test mem stress
-${bin_path}/chaosd attack stress mem -w 1 > mem.out
+${bin_path}/chaosd attack stress mem --size 10M > mem.out
 
 PID=`cat mem.out | grep "stress-ng" | sed 's/.*Pid=\([0-9]*\).*/\1/g'`
 


### PR DESCRIPTION
1. support search all kind experiment
2. remove `workers` config in stress memory, because every worker will cost some cpu load, so just use one worker is OK