### PR TITLE
minor fix on release action

### DIFF
--- a/.github/workflows/release_latest.yml
+++ b/.github/workflows/release_latest.yml
@@ -42,9 +42,7 @@ jobs:
           printf "%s\n" ${{ secrets.AWS_ACCESS_KEY }} ${{ secrets.AWS_SECRET_KEY }} ${{ secrets.AWS_REGION }} "json" | aws configure
 
       - name: Build binary
-        run: |
-          make build
-          make chaos-tools
+        run: make build
 
       - name: Upload files
         run: |

--- a/.github/workflows/release_latest.yml
+++ b/.github/workflows/release_latest.yml
@@ -17,6 +17,15 @@ jobs:
           go-version: 1.16.2
         id: go
 
+      - name: Prepare build environment
+        run: |
+          # actions/checkout require git v2.X
+          yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm
+          yum install -y gcc
+          yum install -y make
+          yum install -y binutils
+          yum install -y git
+
       - uses: actions/checkout@master
         with:
           # Must use at least depth 2!
@@ -32,14 +41,10 @@ jobs:
           pip3 install awscli
           printf "%s\n" ${{ secrets.AWS_ACCESS_KEY }} ${{ secrets.AWS_SECRET_KEY }} ${{ secrets.AWS_REGION }} "json" | aws configure
 
-      - name: Prepare build environment
-        run: |
-          yum install -y gcc
-          yum install -y make
-          yum install -y binutils
-
       - name: Build binary
-        run: make build
+        run: |
+          make build
+          make chaos-tools
 
       - name: Upload files
         run: |
@@ -54,6 +59,7 @@ jobs:
           mkdir chaosd-latest-linux-amd64
           mkdir chaosd-latest-linux-amd64/tools
           mv bin/chaosd chaosd-latest-linux-amd64/
+          mv bin/PortOccupyTool chaosd-latest-linux-amd64/tools/
           mv byteman chaosd-latest-linux-amd64/tools/
           mv stress-ng chaosd-latest-linux-amd64/tools/
 

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -41,9 +41,7 @@ jobs:
           printf "%s\n" ${{ secrets.AWS_ACCESS_KEY }} ${{ secrets.AWS_SECRET_KEY }} ${{ secrets.AWS_REGION }} "json" | aws configure
 
       - name: Build binary
-        run: |
-          make build
-          make chaos-tools
+        run: make build
 
       - name: Upload files
         run: |

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -16,6 +16,15 @@ jobs:
           go-version: 1.16.2
         id: go
 
+      - name: Prepare build environment
+        run: |
+          # actions/checkout require git v2.X
+          yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm
+          yum install -y gcc
+          yum install -y make
+          yum install -y binutils
+          yum install -y git
+
       - uses: actions/checkout@master
         with:
           # Must use at least depth 2!
@@ -31,14 +40,10 @@ jobs:
           pip3 install awscli
           printf "%s\n" ${{ secrets.AWS_ACCESS_KEY }} ${{ secrets.AWS_SECRET_KEY }} ${{ secrets.AWS_REGION }} "json" | aws configure
 
-      - name: Prepare build environment
-        run: |
-          yum install -y gcc
-          yum install -y make
-          yum install -y binutils
-
       - name: Build binary
-        run: make build
+        run: |
+          make build
+          make chaos-tools
 
       - name: Upload files
         run: |
@@ -55,6 +60,7 @@ jobs:
           mkdir chaosd-${GIT_TAG}-linux-amd64
           mkdir chaosd-${GIT_TAG}-linux-amd64/tools
           mv bin/chaosd chaosd-${GIT_TAG}-linux-amd64/
+          mv bin/PortOccupyTool chaosd-${GIT_TAG}-linux-amd64/tools/
           mv byteman chaosd-${GIT_TAG}-linux-amd64/tools/
           mv stress-ng chaosd-${GIT_TAG}-linux-amd64/tools/
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(GOBIN)/goimports:
 
 build: binary
 
-binary: swagger_spec chaosd
+binary: swagger_spec chaosd chaos-tools
 
 taily-build:
 	if [ "$(shell docker ps --filter=name=$@ -q)" = "" ]; then \
@@ -61,6 +61,8 @@ endif
 chaosd:
 	$(CGOENV) go build -ldflags '$(LDFLAGS)' -tags "${BUILD_TAGS}" -o bin/chaosd ./cmd/main.go
 
+chaos-tools:
+	$(CGOENV) go build -o bin/PortOccupyTool tools/PortOccupyTool.go
 
 swagger_spec:
 ifeq ($(SWAGGER),1)


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>
1. download v1.0.0, and execute `chaosd version`, output:

```bash
Chaosd Version: version.Info{GitVersion:"v0.0.0-master+$Format:%h$", GitCommit:"$Format:%H$", BuildDate:"2021-06-22T02:31:24Z", GoVersion:"go1.16.2", Compiler:"gc", Platform:"linux/amd64"}
```
you can see the `GitVersion` and `GitCommit` are wrong. It is because that the ci environment lack `git`.

2. the tools lack `PortOccupyTool`, so can't execute network attack with port occupy.


