### PR TITLE
update binary execute path

### DIFF
--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -20,10 +20,11 @@ import (
 )
 
 func SetRuntimeEnv() error {
-	wd, err := filepath.Abs(filepath.Dir(os.Args[0]))
-	if err != nil {
-		return err
-	}
+	ex, err := os.Executable()
+    if err != nil {
+        return err
+    }
+    wd := filepath.Dir(ex)
 
 	_, err = os.Stat(fmt.Sprintf("%s/tools", wd))
 	if os.IsNotExist(err) {

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -21,10 +21,10 @@ import (
 
 func SetRuntimeEnv() error {
 	ex, err := os.Executable()
-    if err != nil {
-        return err
-    }
-    wd := filepath.Dir(ex)
+	if err != nil {
+		return err
+	}
+	wd := filepath.Dir(ex)
 
 	_, err = os.Stat(fmt.Sprintf("%s/tools", wd))
 	if os.IsNotExist(err) {


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

download `chaosd-latest-linux-amd64`, and add it to the `PATH`, then execute `chaosd attack stress cpu`, will return error:
```log
Error: exec: "stress-ng": executable file not found in $PATH
```

fix this issue