### PR TITLE
support setting uid when injecting fault

### DIFF
--- a/cmd/attack/attack.go
+++ b/cmd/attack/attack.go
@@ -21,13 +21,16 @@ func NewAttackCommand() *cobra.Command {
 		Short: "Attack related commands",
 	}
 
+	var uid string
+	cmd.PersistentFlags().StringVarP(&uid, "uid", "", "", "the experiment ID")
+
 	cmd.AddCommand(
-		NewProcessAttackCommand(),
-		NewNetworkAttackCommand(),
-		NewStressAttackCommand(),
-		NewDiskAttackCommand(),
-		NewHostAttackCommand(),
-		NewJVMAttackCommand(),
+		NewProcessAttackCommand(&uid),
+		NewNetworkAttackCommand(&uid),
+		NewStressAttackCommand(&uid),
+		NewDiskAttackCommand(&uid),
+		NewHostAttackCommand(&uid),
+		NewJVMAttackCommand(&uid),
 	)
 
 	return cmd

--- a/cmd/attack/disk.go
+++ b/cmd/attack/disk.go
@@ -25,11 +25,12 @@ import (
 	"github.com/chaos-mesh/chaosd/pkg/utils"
 )
 
-func NewDiskAttackCommand() *cobra.Command {
+func NewDiskAttackCommand(uid *string) *cobra.Command {
 	options := core.NewDiskOption()
 	dep := fx.Options(
 		server.Module,
 		fx.Provide(func() *core.DiskOption {
+			options.UID = *uid
 			return options
 		}),
 	)

--- a/cmd/attack/host.go
+++ b/cmd/attack/host.go
@@ -25,11 +25,12 @@ import (
 	"github.com/chaos-mesh/chaosd/pkg/utils"
 )
 
-func NewHostAttackCommand() *cobra.Command {
+func NewHostAttackCommand(uid *string) *cobra.Command {
 	options := core.NewHostCommand()
 	dep := fx.Options(
 		server.Module,
 		fx.Provide(func() *core.HostCommand {
+			options.UID = *uid
 			return options
 		}),
 	)

--- a/cmd/attack/jvm.go
+++ b/cmd/attack/jvm.go
@@ -25,11 +25,12 @@ import (
 	"github.com/chaos-mesh/chaosd/pkg/utils"
 )
 
-func NewJVMAttackCommand() *cobra.Command {
+func NewJVMAttackCommand(uid *string) *cobra.Command {
 	options := core.NewJVMCommand()
 	dep := fx.Options(
 		server.Module,
 		fx.Provide(func() *core.JVMCommand {
+			options.UID = *uid
 			return options
 		}),
 	)

--- a/cmd/attack/network.go
+++ b/cmd/attack/network.go
@@ -25,11 +25,12 @@ import (
 	"github.com/chaos-mesh/chaosd/pkg/utils"
 )
 
-func NewNetworkAttackCommand() *cobra.Command {
+func NewNetworkAttackCommand(uid *string) *cobra.Command {
 	options := core.NewNetworkCommand()
 	dep := fx.Options(
 		server.Module,
 		fx.Provide(func() *core.NetworkCommand {
+			options.UID = *uid
 			return options
 		}),
 	)

--- a/cmd/attack/process.go
+++ b/cmd/attack/process.go
@@ -27,11 +27,12 @@ import (
 	"github.com/chaos-mesh/chaosd/pkg/utils"
 )
 
-func NewProcessAttackCommand() *cobra.Command {
+func NewProcessAttackCommand(uid *string) *cobra.Command {
 	options := core.NewProcessCommand()
 	dep := fx.Options(
 		server.Module,
 		fx.Provide(func() *core.ProcessCommand {
+			options.UID = *uid
 			return options
 		}),
 	)

--- a/cmd/attack/stress.go
+++ b/cmd/attack/stress.go
@@ -25,11 +25,12 @@ import (
 	"github.com/chaos-mesh/chaosd/pkg/utils"
 )
 
-func NewStressAttackCommand() *cobra.Command {
+func NewStressAttackCommand(uid *string) *cobra.Command {
 	options := core.NewStressCommand()
 	dep := fx.Options(
 		server.Module,
 		fx.Provide(func() *core.StressCommand {
+			options.UID = *uid
 			return options
 		}),
 	)

--- a/pkg/core/common.go
+++ b/pkg/core/common.go
@@ -33,6 +33,9 @@ type AttackConfig interface {
 
 	// CompleteDefaults is used to fill flags with default values
 	CompleteDefaults()
+
+	// GetUID returns the experiment's ID
+	GetUID() string
 }
 
 type SchedulerConfig struct {
@@ -57,6 +60,7 @@ type CommonAttackConfig struct {
 
 	Action string `json:"action"`
 	Kind   string `json:"kind"`
+	UID    string `json:"uid"`
 }
 
 func (config CommonAttackConfig) String() string {
@@ -78,4 +82,8 @@ func (config *CommonAttackConfig) Validate() error {
 		}
 	}
 	return nil
+}
+
+func (config *CommonAttackConfig) GetUID() string {
+	return config.UID
 }

--- a/pkg/core/experiment_run.go
+++ b/pkg/core/experiment_run.go
@@ -52,7 +52,8 @@ type ExperimentRun struct {
 func (exp Experiment) NewRun() *ExperimentRun {
 	return &ExperimentRun{
 		ExperimentID: exp.ID,
-		UID:          uuid.New().String(),
-		Status:       RunStarted,
+		// TODO: maybe need to use specified uid
+		UID:    uuid.New().String(),
+		Status: RunStarted,
 	}
 }

--- a/pkg/server/chaosd/attack.go
+++ b/pkg/server/chaosd/attack.go
@@ -51,7 +51,10 @@ func (s *Server) ExecuteAttack(attackType AttackType, options core.AttackConfig,
 		return
 	}
 
-	uid = uuid.New().String()
+	uid = options.GetUID()
+	if len(uid) == 0 {
+		uid = uuid.New().String()
+	}
 
 	exp := &core.Experiment{
 		Uid:            uid,


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

user can set the uid when injecting fault, it is more convenient for managing the experiment.