### PR TITLE
Fix signal error

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Attacks a process according to the PID or process name. Supported tasks are:
 
 - **stop process**
 
-    Description: Kills a process by sending the `SIGKILL` signal
+    Description: Stop a process by sending the `SIGSTOP` signal
 
     Sample usage:
 


### PR DESCRIPTION
When stop process,  chaosd send  `SIGSTOP` signal