### PR TITLE
Network: set default value for duplicate and corrupt action && fix partition

### DIFF
--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -213,6 +213,8 @@ func (n *NetworkCommand) CompleteDefaults() {
 		n.setDefaultForNetworkDNS()
 	case NetworkDuplicateAction:
 		n.setDefaultForNetworkDuplicate()
+	case NetworkCorruptAction:
+		n.setDefaultForNetworkCorrupt()
 	}
 }
 
@@ -233,6 +235,12 @@ func (n *NetworkCommand) setDefaultForNetworkLoss() {
 }
 
 func (n *NetworkCommand) setDefaultForNetworkDuplicate() {
+	if len(n.Correlation) == 0 {
+		n.Correlation = "0"
+	}
+}
+
+func (n *NetworkCommand) setDefaultForNetworkCorrupt() {
 	if len(n.Correlation) == 0 {
 		n.Correlation = "0"
 	}

--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -211,6 +211,8 @@ func (n *NetworkCommand) CompleteDefaults() {
 		n.setDefaultForNetworkLoss()
 	case NetworkDNSAction:
 		n.setDefaultForNetworkDNS()
+	case NetworkDuplicateAction:
+		n.setDefaultForNetworkDuplicate()
 	}
 }
 
@@ -225,6 +227,12 @@ func (n *NetworkCommand) setDefaultForNetworkDelay() {
 }
 
 func (n *NetworkCommand) setDefaultForNetworkLoss() {
+	if len(n.Correlation) == 0 {
+		n.Correlation = "0"
+	}
+}
+
+func (n *NetworkCommand) setDefaultForNetworkDuplicate() {
 	if len(n.Correlation) == 0 {
 		n.Correlation = "0"
 	}

--- a/pkg/core/network_rules.go
+++ b/pkg/core/network_rules.go
@@ -424,7 +424,7 @@ func toNetem(spec *TcParameter) (*pb.Netem, error) {
 	for _, spec := range emSpecs {
 		em, err := spec.ToNetem()
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		merged = mergeNetem(merged, em)
 	}

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -66,7 +66,7 @@ func (networkAttack) Attack(options core.AttackConfig, env Environment) (err err
 	case core.NetworkPortOccupiedAction:
 		return env.Chaos.applyPortOccupied(attack)
 
-	case core.NetworkDelayAction, core.NetworkLossAction, core.NetworkCorruptAction, core.NetworkDuplicateAction, core.NetworkBandwidthAction:
+	case core.NetworkDelayAction, core.NetworkLossAction, core.NetworkCorruptAction, core.NetworkDuplicateAction, core.NetworkBandwidthAction, core.NetworkPartitionAction:
 		if attack.NeedApplyIPSet() {
 			ipsetName, err = env.Chaos.applyIPSet(attack, env.AttackUid)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

1. fix issue https://github.com/chaos-mesh/chaosd/issues/116

    The reason is that the `correlation` is "", and parse float failed. Set default value for it in this pr

2. fix partition, it is deleted by mistake in https://github.com/chaos-mesh/chaosd/pull/91 😢 

TODO: add test for them