### PR TITLE
Network: support down NIC

### DIFF
--- a/cmd/attack/network.go
+++ b/cmd/attack/network.go
@@ -282,7 +282,6 @@ func NewNICDownCommand(dep fx.Option, options *core.NetworkCommand) *cobra.Comma
 		},
 	}
 
-	// cmd.Flags().StringVarP(&options.Time, "time", "t", "0s", "duration of disable the nic, set -1 to run continuously")
 	cmd.Flags().StringVarP(&options.Device, "device", "d", "", "the network interface to impact")
 	SetScheduleFlags(cmd, &options.SchedulerConfig)
 	return cmd

--- a/cmd/attack/network.go
+++ b/cmd/attack/network.go
@@ -282,7 +282,8 @@ func NewNICDownCommand(dep fx.Option, options *core.NetworkCommand) *cobra.Comma
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.Time, "time", "t", "0s", "duration of disable the nic, set -1 to run continuously")
+	// cmd.Flags().StringVarP(&options.Time, "time", "t", "0s", "duration of disable the nic, set -1 to run continuously")
 	cmd.Flags().StringVarP(&options.Device, "device", "d", "", "the network interface to impact")
+	SetScheduleFlags(cmd, &options.SchedulerConfig)
 	return cmd
 }

--- a/cmd/attack/network.go
+++ b/cmd/attack/network.go
@@ -49,6 +49,7 @@ func NewNetworkAttackCommand(uid *string) *cobra.Command {
 		NetworkDNSCommand(dep, options),
 		NewNetworkPortOccupiedCommand(dep, options),
 		NewNetworkBandwidthCommand(dep, options),
+		NewNicDownCommand(dep, options),
 	)
 
 	return cmd
@@ -266,5 +267,19 @@ func NewNetworkPortOccupiedCommand(dep fx.Option, options *core.NetworkCommand) 
 	}
 
 	cmd.Flags().StringVarP(&options.Port, "port", "p", "", "this specified port is to occupied")
+	return cmd
+}
+
+func NewNicDownCommand(dep fx.Option, options *core.NetworkCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "down",
+		Short: "down network interface card",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Action = core.NetworkNicDownAction
+			options.CompleteDefaults()
+			utils.FxNewAppWithoutLog(dep, fx.Invoke(commonNetworkAttackFunc)).Run()
+		},
+	}
 	return cmd
 }

--- a/cmd/attack/network.go
+++ b/cmd/attack/network.go
@@ -49,7 +49,7 @@ func NewNetworkAttackCommand(uid *string) *cobra.Command {
 		NetworkDNSCommand(dep, options),
 		NewNetworkPortOccupiedCommand(dep, options),
 		NewNetworkBandwidthCommand(dep, options),
-		NewNicDownCommand(dep, options),
+		NewNICDownCommand(dep, options),
 	)
 
 	return cmd
@@ -270,16 +270,19 @@ func NewNetworkPortOccupiedCommand(dep fx.Option, options *core.NetworkCommand) 
 	return cmd
 }
 
-func NewNicDownCommand(dep fx.Option, options *core.NetworkCommand) *cobra.Command {
+func NewNICDownCommand(dep fx.Option, options *core.NetworkCommand) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "down",
+		Use:   "down",
 		Short: "down network interface card",
 
 		Run: func(cmd *cobra.Command, args []string) {
-			options.Action = core.NetworkNicDownAction
+			options.Action = core.NetworkNICDownAction
 			options.CompleteDefaults()
 			utils.FxNewAppWithoutLog(dep, fx.Invoke(commonNetworkAttackFunc)).Run()
 		},
 	}
+
+	cmd.Flags().StringVarP(&options.Time, "time", "t", "0s", "duration of disable the nic, set -1 to run continuously")
+	cmd.Flags().StringVarP(&options.Device, "device", "d", "", "the network interface to impact")
 	return cmd
 }

--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -57,9 +57,6 @@ type NetworkCommand struct {
 	// only the packet which match the tcp flag can be accepted, others will be dropped.
 	// only set when the IPProtocol is tcp, used for partition.
 	AcceptTCPFlags string `json:"accept-tcp-flags,omitempty"`
-
-	// used for down nic
-	Time string `json:"time,omitempty"`
 }
 
 var _ AttackConfig = &NetworkCommand{}
@@ -212,6 +209,10 @@ func (n *NetworkCommand) validNetworkOccupied() error {
 func (n *NetworkCommand) validNetworkNICDown() error {
 	if len(n.Duration) == 0 {
 		return errors.New("duration is required")
+	}
+
+	if len(n.Device) == 0 {
+		return errors.New("device is required")
 	}
 
 	return nil

--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -210,10 +210,10 @@ func (n *NetworkCommand) validNetworkOccupied() error {
 }
 
 func (n *NetworkCommand) validNetworkNICDown() error {
-	if len(n.Time) == 0 {
-		return errors.New("time is required")
+	if len(n.Duration) == 0 {
+		return errors.New("duration is required")
 	}
-	
+
 	return nil
 }
 

--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -70,6 +70,7 @@ const (
 	NetworkPartitionAction    = "partition"
 	NetworkBandwidthAction    = "bandwidth"
 	NetworkPortOccupiedAction = "occupied"
+	NetworkNicDownAction      = "down"
 )
 
 func (n *NetworkCommand) Validate() error {

--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -57,6 +57,9 @@ type NetworkCommand struct {
 	// only the packet which match the tcp flag can be accepted, others will be dropped.
 	// only set when the IPProtocol is tcp, used for partition.
 	AcceptTCPFlags string `json:"accept-tcp-flags,omitempty"`
+
+	// used for down nic
+	Time string `json:"time,omitempty"`
 }
 
 var _ AttackConfig = &NetworkCommand{}
@@ -70,7 +73,7 @@ const (
 	NetworkPartitionAction    = "partition"
 	NetworkBandwidthAction    = "bandwidth"
 	NetworkPortOccupiedAction = "occupied"
-	NetworkNicDownAction      = "down"
+	NetworkNICDownAction      = "down"
 )
 
 func (n *NetworkCommand) Validate() error {

--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -93,6 +93,8 @@ func (n *NetworkCommand) Validate() error {
 		return n.validNetworkOccupied()
 	case NetworkBandwidthAction:
 		return n.validNetworkBandwidth()
+	case NetworkNICDownAction:
+		return n.validNetworkNICDown()
 	default:
 		return errors.Errorf("network action %s not supported", n.Action)
 	}
@@ -204,6 +206,14 @@ func (n *NetworkCommand) validNetworkOccupied() error {
 	if len(n.Port) == 0 {
 		return errors.New("port is required")
 	}
+	return nil
+}
+
+func (n *NetworkCommand) validNetworkNICDown() error {
+	if len(n.Time) == 0 {
+		return errors.New("time is required")
+	}
+	
 	return nil
 }
 

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -576,7 +576,7 @@ func (s *Server) getNICIP(attack *core.NetworkCommand) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	// When stdoutBytes is converted to string, the string will be IPAddress with a few unnecessary 
+	// When stdoutBytes is converted to string, the string will be IPAddress with a few unnecessary
 	// zeros, which makes IPAddress' format wrong, so the trailing zeros needs to be trimmed.
 	attack.IPAddress = strings.TrimRight(string(stdoutBytes), "\n\x00")
 

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -94,7 +94,9 @@ func (networkAttack) Attack(options core.AttackConfig, env Environment) (err err
 		NICDownCommand := fmt.Sprintf("ifconfig %s down", attack.Device)
 
 		cmd := exec.Command("bash", "-c", NICDownCommand)
-		if err = cmd.Start(); err != nil {
+		stdout, err := cmd.CombinedOutput()
+		if err != nil {
+			log.Error(cmd.String()+string(stdout), zap.Error(err))
 			return errors.WithStack(err)
 		}
 
@@ -535,7 +537,9 @@ func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
 	NICUpCommand := fmt.Sprintf("ifconfig %s %s up", attack.Device, attack.IPAddress)
 
 	recoverCmd := exec.Command("bash", "-c", NICUpCommand)
-	if err := recoverCmd.Start(); err != nil {
+	stdout, err := recoverCmd.CombinedOutput()
+	if err != nil {
+		log.Error(recoverCmd.String()+string(stdout), zap.Error(err))
 		return errors.WithStack(err)
 	}
 
@@ -543,10 +547,12 @@ func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
 }
 
 func (s *Server) recoverNICDownScheduled(attack *core.NetworkCommand) error {
-	NICUpCommand := fmt.Sprintf("sleep %s && nohup ifconfig %s %s up", attack.Duration, attack.Device, attack.IPAddress)
+	NICUpCommand := fmt.Sprintf("sudo sleep %s && nohup ifconfig %s %s up", attack.Duration, attack.Device, attack.IPAddress)
 
 	recoverCmd := exec.Command("bash", "-c", NICUpCommand)
-	if err := recoverCmd.Start(); err != nil {
+	stdout, err := recoverCmd.CombinedOutput()
+	if err != nil {
+		log.Error(recoverCmd.String()+string(stdout), zap.Error(err))
 		return errors.WithStack(err)
 	}
 	return nil

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -93,15 +93,9 @@ func (networkAttack) Attack(options core.AttackConfig, env Environment) (err err
 		if err = cmd.Start(); err != nil {
 			return errors.WithStack(err)
 		}
-		//  duration, err := time.ParseDuration(attack.Time)
-		if err != nil {
-			return errors.WithStack(err)
-		}
+
 		if attack.Duration != "-1" {
-			// time.Sleep(duration)
-			rcmd := fmt.Sprintf("nohup sleep %s && nohup chaosd recover %s", attack.Duration, options.GetUID())
-			exec.Command("/bin/bash", "-c", rcmd)
-			// env.Chaos.recoverNICDown(attack)
+			env.Chaos.recoverNICDownScheduled(attack)
 		}
 	}
 
@@ -534,6 +528,17 @@ func (s *Server) recoverEtcHosts(attack *core.NetworkCommand, uid string) error 
 
 func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
 	NICUpCommand := fmt.Sprintf("ifconfig %s up", attack.Device)
+
+	recoverCmd := exec.Command("/bin/bash", "-c", NICUpCommand)
+	if err := recoverCmd.Start(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (s *Server) recoverNICDownScheduled(attack *core.NetworkCommand) error {
+	NICUpCommand := fmt.Sprintf("nohup sleep %s && nphup ifconfig %s up", attack.Duration, attack.Device)
 
 	recoverCmd := exec.Command("/bin/bash", "-c", NICUpCommand)
 	if err := recoverCmd.Start(); err != nil {

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -576,9 +576,8 @@ func (s *Server) getNICIP(attack *core.NetworkCommand) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	// The number of recived bytes is smaller than 1024, when stdoutBytes is
-	// converted to string, the string will be IPAddress and sort of zeros,
-	// so this string needs to be trimmed trailing zeros.
+	// When stdoutBytes is converted to string, the string will be IPAddress with a few unnecessary 
+	// zeros, which makes IPAddress' format wrong, so the trailing zeros needs to be trimmed.
 	attack.IPAddress = strings.TrimRight(string(stdoutBytes), "\n\x00")
 
 	return nil

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -538,7 +538,7 @@ func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
 }
 
 func (s *Server) recoverNICDownScheduled(attack *core.NetworkCommand) error {
-	NICUpCommand := fmt.Sprintf("nohup sleep %s && nphup ifconfig %s up", attack.Duration, attack.Device)
+	NICUpCommand := fmt.Sprintf("nohup sleep %s && nohup ifconfig %s up", attack.Duration, attack.Device)
 
 	recoverCmd := exec.Command("/bin/bash", "-c", NICUpCommand)
 	if err := recoverCmd.Start(); err != nil {

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -24,7 +24,6 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/bpm"
 	"github.com/shirou/gopsutil/process"
@@ -94,7 +93,7 @@ func (networkAttack) Attack(options core.AttackConfig, env Environment) (err err
 		if err = cmd.Start(); err != nil {
 			return errors.WithStack(err)
 		}
-		duration, err := time.ParseDuration(attack.Time)
+		//  duration, err := time.ParseDuration(attack.Time)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -555,6 +555,9 @@ func (s *Server) recoverNICDownScheduled(attack *core.NetworkCommand) error {
 	return nil
 }
 
+// getNICIP() uses `ifconfig` to get interfaces' IP. The reason for
+// not using net.Interfaces() is that net.Interfaces() can't get
+// sub interfaces.
 func (s *Server) getNICIP(attack *core.NetworkCommand) error {
 	getIPCommand := fmt.Sprintf("ifconfig %s | awk '/inet\\>/ {print $2}'", attack.Device)
 
@@ -573,6 +576,9 @@ func (s *Server) getNICIP(attack *core.NetworkCommand) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	// The number of recived bytes is smaller than 1024, when stdoutBytes is
+	// converted to string, the string will be IPAddress and sort of zeros,
+	// so this string needs to be trimmed trailing zeros.
 	attack.IPAddress = strings.TrimRight(string(stdoutBytes), "\n\x00")
 
 	return nil

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -97,7 +97,7 @@ func (networkAttack) Attack(options core.AttackConfig, env Environment) (err err
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		if attack.Time != "-1" {
+		if attack.Duration != "-1" {
 			// time.Sleep(duration)
 			rcmd := fmt.Sprintf("nohup sleep %s && nohup chaosd recover %s", attack.Duration, options.GetUID())
 			exec.Command("/bin/bash", "-c", rcmd)

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -94,9 +94,8 @@ func (networkAttack) Attack(options core.AttackConfig, env Environment) (err err
 		NICDownCommand := fmt.Sprintf("ifconfig %s down", attack.Device)
 
 		cmd := exec.Command("bash", "-c", NICDownCommand)
-		stdout, err := cmd.CombinedOutput()
+		_, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Error(cmd.String()+string(stdout), zap.Error(err))
 			return errors.WithStack(err)
 		}
 
@@ -537,9 +536,8 @@ func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
 	NICUpCommand := fmt.Sprintf("ifconfig %s %s up", attack.Device, attack.IPAddress)
 
 	recoverCmd := exec.Command("bash", "-c", NICUpCommand)
-	stdout, err := recoverCmd.CombinedOutput()
+	_, err := recoverCmd.CombinedOutput()
 	if err != nil {
-		log.Error(recoverCmd.String()+string(stdout), zap.Error(err))
 		return errors.WithStack(err)
 	}
 
@@ -550,9 +548,8 @@ func (s *Server) recoverNICDownScheduled(attack *core.NetworkCommand) error {
 	NICUpCommand := fmt.Sprintf("sleep %s && ifconfig %s %s up", attack.Duration, attack.Device, attack.IPAddress)
 
 	recoverCmd := exec.Command("bash", "-c", NICUpCommand)
-	stdout, err := recoverCmd.CombinedOutput()
+	_, err := recoverCmd.CombinedOutput()
 	if err != nil {
-		log.Error(recoverCmd.String()+string(stdout), zap.Error(err))
 		return errors.WithStack(err)
 	}
 	return nil

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -98,10 +98,8 @@ func (networkAttack) Attack(options core.AttackConfig, env Environment) (err err
 		if err != nil {
 			return errors.WithStack(err)
 		}
-
-		time.Sleep(duration)
-
 		if attack.Time != "-1" {
+			// time.Sleep(duration)
 			env.Chaos.recoverNICDown(attack)
 		}
 	}
@@ -534,10 +532,10 @@ func (s *Server) recoverEtcHosts(attack *core.NetworkCommand, uid string) error 
 }
 
 func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
-	NICUpCommand := fmt.Sprintf("nohup sudo ifconfig %s up", attack.Device)
+	NICUpCommand := fmt.Sprintf("nohup sleep %s && nohup ifconfig %s up", attack.Time, attack.Device)
 
-	cmd := exec.Command("bash", "-c", NICUpCommand)
-	if err := cmd.Start(); err != nil {
+	recoverCmd := exec.Command("/bin/bash", "-c", NICUpCommand)
+	if err := recoverCmd.Start(); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -99,7 +99,9 @@ func (networkAttack) Attack(options core.AttackConfig, env Environment) (err err
 		}
 		if attack.Time != "-1" {
 			// time.Sleep(duration)
-			env.Chaos.recoverNICDown(attack)
+			rcmd := fmt.Sprintf("nohup sleep %s && nohup chaosd recover %s", attack.Duration, options.GetUID())
+			exec.Command("/bin/bash", "-c", rcmd)
+			// env.Chaos.recoverNICDown(attack)
 		}
 	}
 
@@ -531,7 +533,7 @@ func (s *Server) recoverEtcHosts(attack *core.NetworkCommand, uid string) error 
 }
 
 func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
-	NICUpCommand := fmt.Sprintf("nohup sleep %s && nohup ifconfig %s up", attack.Time, attack.Device)
+	NICUpCommand := fmt.Sprintf("ifconfig %s up", attack.Device)
 
 	recoverCmd := exec.Command("/bin/bash", "-c", NICUpCommand)
 	if err := recoverCmd.Start(); err != nil {

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -532,7 +532,7 @@ func (s *Server) recoverEtcHosts(attack *core.NetworkCommand, uid string) error 
 }
 
 func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
-	NICUpCommand := fmt.Sprintf("ifconfig %s up", attack.Device)
+	NICUpCommand := fmt.Sprintf("ifconfig %s %s up", attack.Device, attack.IPAddress)
 
 	recoverCmd := exec.Command("bash", "-c", NICUpCommand)
 	if err := recoverCmd.Start(); err != nil {
@@ -543,12 +543,10 @@ func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
 }
 
 func (s *Server) recoverNICDownScheduled(attack *core.NetworkCommand) error {
-	NICUpCommand := fmt.Sprintf("nohup ifconfig %s %s up", attack.Device, attack.IPAddress)
-	fmt.Println("NICUpCommand:", NICUpCommand)
-	recoverCmd := exec.Command("/bin/bash", "-c", NICUpCommand)
+	NICUpCommand := fmt.Sprintf("sleep %s && nohup ifconfig %s %s up", attack.Duration, attack.Device, attack.IPAddress)
+
+	recoverCmd := exec.Command("bash", "-c", NICUpCommand)
 	if err := recoverCmd.Start(); err != nil {
-		fmt.Println("recoverCmd:", recoverCmd.String())
-		fmt.Println(err)
 		return errors.WithStack(err)
 	}
 	return nil
@@ -572,7 +570,7 @@ func (s *Server) getNICIP(attack *core.NetworkCommand) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	attack.IPAddress = strings.Replace(string(stdoutBytes), "\n", "", -1)
+	attack.IPAddress = strings.TrimRight(string(stdoutBytes), "\n\x00")
 
 	return nil
 }

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -547,7 +547,7 @@ func (s *Server) recoverNICDown(attack *core.NetworkCommand) error {
 }
 
 func (s *Server) recoverNICDownScheduled(attack *core.NetworkCommand) error {
-	NICUpCommand := fmt.Sprintf("sudo sleep %s && nohup ifconfig %s %s up", attack.Duration, attack.Device, attack.IPAddress)
+	NICUpCommand := fmt.Sprintf("sleep %s && ifconfig %s %s up", attack.Duration, attack.Device, attack.IPAddress)
 
 	recoverCmd := exec.Command("bash", "-c", NICUpCommand)
 	stdout, err := recoverCmd.CombinedOutput()

--- a/test/integration_test/network/run.sh
+++ b/test/integration_test/network/run.sh
@@ -41,8 +41,10 @@ if [[ -n ${stat} ]]; then
 fi
 
 sleep 2s
-
+ifconfig
 stat=$(ifconfig | grep ${test_nic} | sed 's/:0:.*/:0/g')
+echo ${stat}
+echo ${test_nic}
 if [[ ${stat} != ${test_nic} ]]; then
     echo "fail to enable the test nic"
     exit 1

--- a/test/integration_test/network/run.sh
+++ b/test/integration_test/network/run.sh
@@ -40,11 +40,9 @@ if [[ -n ${stat} ]]; then
     exit 1
 fi
 
-sleep 2s
-ifconfig
+sleep 1s
+
 stat=$(ifconfig | grep ${test_nic} | sed 's/:0:.*/:0/g')
-echo ${stat}
-echo ${test_nic}
 if [[ ${stat} != ${test_nic} ]]; then
     echo "fail to enable the test nic"
     exit 1

--- a/test/integration_test/network/run.sh
+++ b/test/integration_test/network/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Chaos Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+cur=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd $cur
+
+bin_path=../../../bin
+
+# test nic down
+nic=$(cat /proc/net/dev | awk '{i++; if(i>2){print $1}}' | sed 's/^[\t]*//g' | sed 's/[:]*$//g' | head -n 1)
+
+ifconfig ${nic}:0 192.168.10.28 up
+
+test_nic=$(ifconfig | grep ${nic}:0 | sed 's/:0:.*/:0/g')
+if [[ test_nic == "" ]]; then
+    echo "create test nic failed"
+    exit 1
+fi
+
+${bin_path}/chaosd attack network down -d ${test_nic} --duration 1s
+stat=$(ifconfig | grep ${test_nic} | sed 's/:0:.*/:0/g')
+
+if [[ -n ${stat} ]]; then
+    echo "fail to disable the test nic"
+    ifconfig ${test_nic} down
+    exit 1
+fi
+
+sleep 2s
+
+stat=$(ifconfig | grep ${test_nic} | sed 's/:0:.*/:0/g')
+if [[ ${stat} != ${test_nic} ]]; then
+    echo "fail to enable the test nic"
+    exit 1
+fi
+
+ifconfig ${test_nic} down
+
+exit 0


### PR DESCRIPTION
**Notice:** The parameter `duration` is set to mandatory, because disabling the remote server's NIC is dangerous.