### PR TITLE
ignore process not found while recovering the stress

### DIFF
--- a/pkg/server/chaosd/stress.go
+++ b/pkg/server/chaosd/stress.go
@@ -15,7 +15,7 @@ package chaosd
 
 import (
 	"errors"
-	"os"
+	"io/fs"
 	"strings"
 	"syscall"
 
@@ -92,7 +92,7 @@ func (stressAttack) Recover(exp core.Experiment, _ Environment) error {
 	attack := config.(*core.StressCommand)
 	proc, err := process.NewProcess(attack.StressngPid)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 

--- a/pkg/server/chaosd/stress.go
+++ b/pkg/server/chaosd/stress.go
@@ -15,6 +15,7 @@ package chaosd
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"syscall"
 
@@ -91,6 +92,10 @@ func (stressAttack) Recover(exp core.Experiment, _ Environment) error {
 	attack := config.(*core.StressCommand)
 	proc, err := process.NewProcess(attack.StressngPid)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

If the process is not found, we can assume that it's already been recovered (or killed by other processes, like oom killer).