### PR TITLE
JVM attack: minor fix on memory

### DIFF
--- a/pkg/server/chaosd/jvm.go
+++ b/pkg/server/chaosd/jvm.go
@@ -34,7 +34,7 @@ type jvmAttack struct{}
 
 var JVMAttack AttackType = jvmAttack{}
 
-const bmInstallCommand = "bminstall.sh -b -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose -p %d %d"
+const bmInstallCommand = "bminstall.sh -b -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose -Dorg.jboss.byteman.compileToBytecode -p %d %d"
 const bmSubmitCommand = "bmsubmit.sh -p %d -%s %s"
 
 func (j jvmAttack) Attack(options core.AttackConfig, env Environment) (err error) {
@@ -180,7 +180,7 @@ func generateRuleData(attack *core.JVMCommand) (string, error) {
 		if attack.CPUCount > 0 {
 			bytemanTemplateSpec.Do = fmt.Sprintf("injectCPUStress(\"%s\", %d)", attack.Name, attack.CPUCount)
 		} else {
-			bytemanTemplateSpec.Do = fmt.Sprintf("injectMemStress(\"%s\", %s)", attack.Name, attack.MemoryType)
+			bytemanTemplateSpec.Do = fmt.Sprintf("injectMemStress(\"%s\", \"%s\")", attack.Name, attack.MemoryType)
 		}
 	case core.JVMGCAction:
 		bytemanTemplateSpec.Helper = core.GCHelper

--- a/pkg/server/chaosd/jvm_test.go
+++ b/pkg/server/chaosd/jvm_test.go
@@ -97,7 +97,7 @@ func TestGenerateRuleData(t *testing.T) {
 					MemoryType: "heap",
 				},
 			},
-			"\nRULE test\nCLASS org.chaos_mesh.chaos_agent.TriggerThread\nMETHOD triggerFunc\nHELPER org.chaos_mesh.byteman.helper.StressHelper\nAT ENTRY\nBIND flag:boolean=true;\nIF true\nDO\n\tinjectMemStress(\"test\", heap);\nENDRULE\n",
+			"\nRULE test\nCLASS org.chaos_mesh.chaos_agent.TriggerThread\nMETHOD triggerFunc\nHELPER org.chaos_mesh.byteman.helper.StressHelper\nAT ENTRY\nBIND flag:boolean=true;\nIF true\nDO\n\tinjectMemStress(\"test\", \"heap\");\nENDRULE\n",
 		},
 		{
 			&core.JVMCommand{

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -43,8 +43,5 @@ func SetRuntimeEnv() error {
 		return err
 	}
 
-	path = os.Getenv("PATH")
-	fmt.Println("PATH:", path)
-
 	return nil
 }

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -37,10 +37,14 @@ func SetRuntimeEnv() error {
 	if err != nil {
 		return err
 	}
+
 	err = os.Setenv("PATH", fmt.Sprintf("%s/tools:%s/bin:%s", wd, bytemanHome, path))
 	if err != nil {
 		return err
 	}
+
+	path = os.Getenv("PATH")
+	fmt.Println("PATH:", path)
 
 	return nil
 }


### PR DESCRIPTION
1. The generated byteman rule for memory stress is wrong, fix it.
2. Update the `bminstall.sh` command according to https://github.com/chaos-mesh/chaos-mesh/pull/2945 by the way.