### PR TITLE
JVM attack: add json label for MySQL config

### DIFF
--- a/cmd/attack/attack.go
+++ b/cmd/attack/attack.go
@@ -44,5 +44,5 @@ func NewAttackCommand() *cobra.Command {
 
 func SetScheduleFlags(cmd *cobra.Command, conf *core.SchedulerConfig) {
 	cmd.Flags().StringVar(&conf.Duration, "duration", "",
-		`Work duration of attacks.A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
+		`Work duration of attacks.A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m".Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
 }

--- a/pkg/core/jvm.go
+++ b/pkg/core/jvm.go
@@ -144,19 +144,19 @@ type JVMStressSpec struct {
 //   only when ((Database == "test" || Database == "") && (Table == "t1" || Table == "") && (SQLType == "select" || SQLType == "")) is true, chaosd will inject fault
 type JVMMySQLSpec struct {
 	// the version of mysql-connector-java, only support 5.X.X(set to 5) and 8.X.X(set to 8) now
-	MySQLConnectorVersion string
+	MySQLConnectorVersion string `json:"mysql-connector-version,omitempty"`
 
 	// the match database
 	// default value is "", means match all database
-	Database string
+	Database string `json:"database,omitempty"`
 
 	// the match table
 	// default value is "", means match all table
-	Table string
+	Table string `json:"table,omitempty"`
 
 	// the match sql type
 	// default value is "", means match all SQL type
-	SQLType string
+	SQLType string `json:"sql-type,omitempty"`
 }
 
 type BytemanTemplateSpec struct {


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

1. add json label for MySQL config in JVM attack
2. minor fix on the description of duration