### PR TITLE
stress attack: ignore error when stress-ng process is not exists

### DIFF
--- a/pkg/server/chaosd/stress.go
+++ b/pkg/server/chaosd/stress.go
@@ -92,7 +92,8 @@ func (stressAttack) Recover(exp core.Experiment, _ Environment) error {
 	attack := config.(*core.StressCommand)
 	proc, err := process.NewProcess(attack.StressngPid)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+		log.Warn("Failed to get stress-ng process", zap.Error(err))
+		if errors.Is(err, process.ErrorProcessNotRunning) || errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

minor fix on https://github.com/chaos-mesh/chaosd/pull/145