### PR TITLE
network: generate network traffic by using iperf

### DIFF
--- a/cmd/attack/network.go
+++ b/cmd/attack/network.go
@@ -50,6 +50,7 @@ func NewNetworkAttackCommand(uid *string) *cobra.Command {
 		NewNetworkPortOccupiedCommand(dep, options),
 		NewNetworkBandwidthCommand(dep, options),
 		NewNICDownCommand(dep, options),
+		NewNetworkFloodCommand(dep, options),
 	)
 
 	return cmd
@@ -267,6 +268,27 @@ func NewNetworkPortOccupiedCommand(dep fx.Option, options *core.NetworkCommand) 
 	}
 
 	cmd.Flags().StringVarP(&options.Port, "port", "p", "", "this specified port is to occupied")
+	return cmd
+}
+
+func NewNetworkFloodCommand(dep fx.Option, options *core.NetworkCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "flood",
+		Short: "generate a mount of network traffic by using iperf",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			options.Action = core.NetworkFloodAction
+			options.CompleteDefaults()
+			utils.FxNewAppWithoutLog(dep, fx.Invoke(commonNetworkAttackFunc)).Run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.Rate, "rate", "r", "", "the speed of network traffic, allows bps, kbps, mbps, gbps, tbps unit. bps means bytes per second")
+	cmd.Flags().StringVarP(&options.IPAddress, "ip", "i", "", "generate traffic to this IP address")
+	cmd.Flags().StringVarP(&options.Port, "port", "p", "", "generate traffic to this port on the IP address")
+	cmd.Flags().Int32VarP(&options.Parallel, "parallel", "", 1, "number of iperf parallel client threads to run")
+	cmd.Flags().StringVarP(&options.Duration, "duration", "", "99999999", "number of seconds to run the iperf test")
+
 	return cmd
 }
 

--- a/cmd/attack/network.go
+++ b/cmd/attack/network.go
@@ -274,7 +274,7 @@ func NewNetworkPortOccupiedCommand(dep fx.Option, options *core.NetworkCommand) 
 func NewNetworkFloodCommand(dep fx.Option, options *core.NetworkCommand) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "flood",
-		Short: "generate a mount of network traffic by using iperf",
+		Short: "generate a mount of network traffic by using iperf client",
 
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Action = core.NetworkFloodAction

--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -230,6 +230,10 @@ func (n *NetworkCommand) validNetworkNICDown() error {
 }
 
 func (n *NetworkCommand) validNetworkFlood() error {
+	if len(n.IPAddress) == 0 {
+		return errors.New("IP is required")
+	}
+
 	if !utils.CheckIPs(n.IPAddress) {
 		return errors.Errorf("ip addressed %s not valid", n.IPAddress)
 	}

--- a/pkg/core/network.go
+++ b/pkg/core/network.go
@@ -49,7 +49,7 @@ type NetworkCommand struct {
 	DNSIp         string `json:"dns-ip,omitempty"`
 	DNSDomainName string `json:"dns-domain-name,omitempty"`
 
-	// used for port occupied
+	// used for port occupied or flood
 	Port    string `json:"port,omitempty"`
 	PortPid int32  `json:"port-pid,omitempty"`
 
@@ -57,6 +57,14 @@ type NetworkCommand struct {
 	// only the packet which match the tcp flag can be accepted, others will be dropped.
 	// only set when the IPProtocol is tcp, used for partition.
 	AcceptTCPFlags string `json:"accept-tcp-flags,omitempty"`
+
+	// used for flood
+	// number of iperf parallel client threads to run
+	Parallel int32 `json:"parallel,omitempty"`
+
+	// used for flood
+	// the pid of iperf
+	IperfPid int32 `json:"iperf-pid,omitempty"`
 }
 
 var _ AttackConfig = &NetworkCommand{}
@@ -71,6 +79,7 @@ const (
 	NetworkBandwidthAction    = "bandwidth"
 	NetworkPortOccupiedAction = "occupied"
 	NetworkNICDownAction      = "down"
+	NetworkFloodAction        = "flood"
 )
 
 func (n *NetworkCommand) Validate() error {
@@ -92,6 +101,8 @@ func (n *NetworkCommand) Validate() error {
 		return n.validNetworkBandwidth()
 	case NetworkNICDownAction:
 		return n.validNetworkNICDown()
+	case NetworkFloodAction:
+		return n.validNetworkFlood()
 	default:
 		return errors.Errorf("network action %s not supported", n.Action)
 	}
@@ -213,6 +224,26 @@ func (n *NetworkCommand) validNetworkNICDown() error {
 
 	if len(n.Device) == 0 {
 		return errors.New("device is required")
+	}
+
+	return nil
+}
+
+func (n *NetworkCommand) validNetworkFlood() error {
+	if !utils.CheckIPs(n.IPAddress) {
+		return errors.Errorf("ip addressed %s not valid", n.IPAddress)
+	}
+
+	if len(n.Port) == 0 {
+		return errors.New("port is required")
+	}
+
+	if len(n.Rate) == 0 {
+		return errors.New("rate is required")
+	}
+
+	if len(n.Duration) == 0 {
+		return errors.New("duration is required")
 	}
 
 	return nil

--- a/pkg/server/chaosd/stress.go
+++ b/pkg/server/chaosd/stress.go
@@ -92,7 +92,8 @@ func (stressAttack) Recover(exp core.Experiment, _ Environment) error {
 	attack := config.(*core.StressCommand)
 	proc, err := process.NewProcess(attack.StressngPid)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+		log.Warn("Failed to get stress-ng process", zap.Error(err))
+		if errors.Is(err, process.ErrorProcessNotRunning) || errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

```shell
./bin/chaosd attack network flood -h
generate a mount of network traffic by using iperf

Usage:
  chaosd attack network flood [flags]

Flags:
      --duration string   number of seconds to run the iperf test (default "99999999")
  -h, --help              help for flood
  -i, --ip string         generate traffic to this IP address
      --parallel int32    number of iperf parallel client threads to run (default 1)
  -p, --port string       generate traffic to this port on the IP address
  -r, --rate string       the speed of network traffic, allows bps, kbps, mbps, gbps, tbps unit. bps means bytes per second

Global Flags:
      --log-level string   the log level of chaosd. The value can be 'debug', 'info', 'warn' and 'error'
      --uid string         the experiment ID
```