### PR TITLE
kafka attack: fill action support change retention bytes

### DIFF
--- a/cmd/attack/kafka.go
+++ b/cmd/attack/kafka.go
@@ -69,6 +69,7 @@ func NewKafkaFillCommand(dep fx.Option, options *core.KafkaCommand) *cobra.Comma
 	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "the password of kafka client")
 	cmd.Flags().UintVarP(&options.MessageSize, "size", "s", 4*1024, "the size of each message")
 	cmd.Flags().Uint64VarP(&options.MaxBytes, "max-bytes", "m", 1<<34, "the max bytes to fill")
+	cmd.Flags().StringVarP(&options.ReloadCommand, "reload-cmd", "r", "", "the command to reload kafka config")
 	return cmd
 }
 

--- a/pkg/core/kafka.go
+++ b/pkg/core/kafka.go
@@ -46,16 +46,22 @@ type KafkaCommand struct {
 	MessageSize uint
 	MaxBytes    uint64
 
+	// options for fill attack
+	ReloadCommand string
+
 	// options for flood attack
 	Threads uint
 
+	// options for fill and io attack
+	ConfigFile string
+
 	// options for io attack
-	ConfigFile  string
 	NonReadable bool
 	NonWritable bool
 
 	// recover data for io attack
-	OriginModeOfFiles map[string]uint32
+	OriginModeOfFiles    map[string]uint32
+	OriginRetentionBytes uint64
 }
 
 func (c *KafkaCommand) Validate() error {
@@ -91,6 +97,12 @@ func (c *KafkaCommand) validateDSNAndMessageSize() error {
 func (c *KafkaCommand) validateFillAction() error {
 	if c.MaxBytes == 0 {
 		return errors.New("max bytes is required")
+	}
+	if c.ReloadCommand == "" {
+		return errors.New("reload command is required")
+	}
+	if _, err := os.Stat(c.ConfigFile); errors.Is(err, os.ErrNotExist) {
+		return errors.Errorf("config file %s not exists", c.ConfigFile)
 	}
 	return c.validateDSNAndMessageSize()
 }

--- a/pkg/core/kafka.go
+++ b/pkg/core/kafka.go
@@ -60,8 +60,8 @@ type KafkaCommand struct {
 	NonWritable bool
 
 	// recover data for io attack
-	OriginModeOfFiles    map[string]uint32
-	OriginRetentionBytes uint64
+	OriginModeOfFiles map[string]uint32
+	OriginConfig      string
 }
 
 func (c *KafkaCommand) Validate() error {


### PR DESCRIPTION
## Example

```bash
> # fill topic test with 1000_000 bytes, set `log.retention.bytes` to 1000_000 and reload config by `systemctl restart kafka`
> sudo bin/chaosd attack kafka fill -T test -m 1000_000 -r "systemctl restart kafka"
```