### PR TITLE
Make byteman plugins runnable on jdk8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GO     := $(GOENV) go
 CGO    := $(CGOENV) go
 GOTEST := TEST_USE_EXISTING_CLUSTER=false NO_PROXY="${NO_PROXY},testhost" go test
 SHELL    := /usr/bin/env bash
-BYTEMAN_DIR := byteman-chaos-mesh-download-v4.0.18-0.9
+BYTEMAN_DIR := byteman-chaos-mesh-download-v4.0.18-0.10
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/test/integration_test/jvm/run.sh
+++ b/test/integration_test/jvm/run.sh
@@ -26,7 +26,7 @@ if [[ ! (-e byteman-example) ]]; then
 fi
 
 echo "download byteman && set environment variable"
-byteman_dir="byteman-chaos-mesh-download-v4.0.18-0.9"
+byteman_dir="byteman-chaos-mesh-download-v4.0.18-0.10"
 if [[ ! (-e ${byteman_dir}.tar.gz) ]]; then
     curl -fsSL -o ${byteman_dir}.tar.gz https://mirrors.chaos-mesh.org/${byteman_dir}.tar.gz
     tar zxvf ${byteman_dir}.tar.gz


### PR DESCRIPTION
Signed-off-by: Cwen Yin <cwenyin0@gmail.com>. 

Update byteman-helper version to v4.0.18-0.10, in this version, we make byteman plugins runnable on idk8 

https://github.com/chaos-mesh/byteman-helper/pull/15 