### PR TITLE
kafka io attack: add username and password flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           elif [[ "$job" == "unit-test" ]]; then
             make unit-test
           elif [[ "$job" == "integration-test" ]]; then
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
             sudo apt-get update
             sudo apt-get install -y stress-ng
             make integration-test

--- a/cmd/attack/kafka.go
+++ b/cmd/attack/kafka.go
@@ -103,6 +103,10 @@ func NewKafkaIOCommand(dep fx.Option, options *core.KafkaCommand) *cobra.Command
 		},
 	}
 
+	cmd.Flags().StringVarP(&options.Host, "host", "H", "localhost", "the host of kafka server")
+	cmd.Flags().Uint16VarP(&options.Port, "port", "P", 9092, "the port of kafka server")
+	cmd.Flags().StringVarP(&options.Username, "username", "u", "", "the username of kafka client")
+	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "the password of kafka client")
 	cmd.Flags().StringVarP(&options.ConfigFile, "config", "c", "/etc/kafka/server.properties", "the path of server config")
 	cmd.Flags().BoolVarP(&options.NonReadable, "non-readable", "r", false, "make kafka cluster non-readable")
 	cmd.Flags().BoolVarP(&options.NonWritable, "non-writable", "w", false, "make kafka cluster non-writable")


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com> 

add username and password flags to fix this
![image](https://user-images.githubusercontent.com/22956341/215315064-9138b66f-8615-4111-81c6-fd549195c408.png)  

Chaosd will access Kafka server to get partitions when to exec io attack. So username, password, host, and port should be supported. 
https://github.com/chaos-mesh/chaosd/blob/a9c05406d24511bc692253508950aa93fb9d0394/pkg/server/chaosd/kafka.go#L385-L387
