### PR TITLE
drop io/ioutil package.

### DIFF
--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -16,7 +16,6 @@ package client
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/pingcap/errors"
@@ -71,14 +70,14 @@ func dial(cli *http.Client, req *http.Request) ([]byte, []byte, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		var apiErr []byte
-		apiErr, err = ioutil.ReadAll(resp.Body)
+		apiErr, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, nil, err
 		}
 		return nil, apiErr, nil
 	}
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/server/chaosd/http.go
+++ b/pkg/server/chaosd/http.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os/exec"
@@ -170,7 +169,7 @@ func attackHTTPRequest(attackConf *core.HTTPAttackConfig) error {
 				return errors.Wrap(err, "HTTP request")
 			}
 			defer resp.Body.Close()
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return errors.Wrap(err, "read response body")
 			}
@@ -183,7 +182,7 @@ func attackHTTPRequest(attackConf *core.HTTPAttackConfig) error {
 				return errors.Wrap(err, "HTTP request")
 			}
 			defer resp.Body.Close()
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return errors.Wrap(err, "read response body")
 			}

--- a/pkg/server/chaosd/jvm.go
+++ b/pkg/server/chaosd/jvm.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -106,7 +105,7 @@ func (j jvmAttack) generateRuleFile(attack *core.JVMCommand) (string, error) {
 	}
 
 	if len(attack.RuleFile) > 0 {
-		data, err := ioutil.ReadFile(attack.RuleFile)
+		data, err := os.ReadFile(attack.RuleFile)
 		if err != nil {
 			return "", err
 		}
@@ -240,7 +239,7 @@ func generateRuleData(attack *core.JVMCommand) (string, error) {
 }
 
 func writeDataIntoFile(data string, filename string) (string, error) {
-	tmpfile, err := ioutil.TempFile("", filename)
+	tmpfile, err := os.CreateTemp("", filename)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/server/chaosd/kafka.go
+++ b/pkg/server/chaosd/kafka.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -226,7 +225,7 @@ func attackKafkaFill(ctx context.Context, attack *core.KafkaCommand) (err error)
 
 func recoverKafkaFill(attack *core.KafkaCommand) error {
 	newConfigFile := attack.ConfigFile + ".new"
-	if err := ioutil.WriteFile(newConfigFile, []byte(attack.OriginConfig), 0644); err != nil {
+	if err := os.WriteFile(newConfigFile, []byte(attack.OriginConfig), 0644); err != nil {
 		return perr.Wrapf(err, "write config file %s", newConfigFile)
 	}
 	err := os.Rename(newConfigFile, attack.ConfigFile)
@@ -254,7 +253,7 @@ func setRetentionBytes(attack *core.KafkaCommand, bytes uint64) (string, error) 
 	}
 	p.Set("log.retention.bytes", fmt.Sprintf("%d", bytes))
 	newConfigFile := attack.ConfigFile + ".new"
-	if err = ioutil.WriteFile(newConfigFile, []byte(p.String()), 0644); err != nil {
+	if err = os.WriteFile(newConfigFile, []byte(p.String()), 0644); err != nil {
 		return "", perr.Wrapf(err, "write config file %s", newConfigFile)
 	}
 	err = os.Rename(newConfigFile, attack.ConfigFile)

--- a/pkg/server/chaosd/network.go
+++ b/pkg/server/chaosd/network.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -276,7 +275,7 @@ func (s *Server) applyEtcHosts(attack *core.NetworkCommand, uid string, env Envi
 		return perrors.WithStack(err)
 	}
 
-	fileBytes, err := ioutil.ReadFile("/etc/hosts.chaosd." + uid) // #nosec
+	fileBytes, err := os.ReadFile("/etc/hosts.chaosd." + uid) // #nosec
 	if err != nil {
 		return perrors.WithStack(err)
 	}

--- a/pkg/utils/tempfile.go
+++ b/pkg/utils/tempfile.go
@@ -14,7 +14,7 @@
 package utils
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -23,7 +23,7 @@ import (
 
 // CreateTempFile will create a temp file in current directory.
 func CreateTempFile(path string) (string, error) {
-	tempFile, err := ioutil.TempFile(path, "example")
+	tempFile, err := os.CreateTemp(path, "example")
 	if err != nil {
 		log.Error("unexpected err when open temp file", zap.Error(err))
 		return "", err
@@ -36,7 +36,7 @@ func CreateTempFile(path string) (string, error) {
 			return "", err
 		}
 	} else {
-		err := errors.Errorf("unexpected err : file get from ioutil.TempFile is nil")
+		err := errors.Errorf("unexpected err : file get from os.CreateTemp is nil")
 		return "", err
 	}
 	return tempFile.Name(), nil


### PR DESCRIPTION
/kind cleanup

Drop ioutil package.
As it is deprecation , and can be replaced well.

```
Deprecated: As of Go 1.16, the same functionality is now 
provided by package [io](https://pkg.go.dev/io) 
or package [os](https://pkg.go.dev/os), 
and those implementations should be preferred in new code
```