### PR TITLE
Bump go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM pingcap/chaos-build-base AS go_build
 
-RUN curl https://dl.google.com/go/go1.14.6.linux-amd64.tar.gz | tar -xz -C /usr/local
+RUN curl https://dl.google.com/go/go1.22.2.linux-amd64.tar.gz | tar -xz -C /usr/local
 ENV PATH "/usr/local/go/bin:${PATH}"
 ENV GO111MODULE=on
 


### PR DESCRIPTION
Building fails with the old version that is currently there. It would anyway be good to bump the version to stay on maintained and secure versions.

When I try to build with go1.14.6 (currently on main) I get the following:

```
 => [go_build 5/6] COPY . /src                                                                                                                                                                         0.1s
 => ERROR [go_build 6/6] RUN --mount=type=cache,target=/root/go/pkg     --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/src/ui/node_modules     IMG_LDFLAGS=$LDFLAGS m  1.0s
------                                                                                                                                                                                                      
 > [go_build 6/6] RUN --mount=type=cache,target=/root/go/pkg     --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/src/ui/node_modules     IMG_LDFLAGS=$LDFLAGS make binary:   
#0 0.333 GO15VENDOREXPERIMENT="1" CGO_ENABLED=1 GOOS="" GOARCH="" go build -ldflags '-s -w -X 'github.com/chaos-mesh/chaosd/pkg/version.buildDate=2024-04-15T12:57:03Z' -X 'github.com/chaos-mesh/chaosd/pkg/version.gitCommit=bc039aa483410318170a542f6cf120b7d3391931' -X 'github.com/chaos-mesh/chaosd/pkg/version.gitVersion=main-gbc039aa4834103'' -tags "" -o bin/chaosd ./cmd/main.go                            
#0 0.812 /root/go/pkg/mod/github.com/chaos-mesh/chaos-mesh@v0.9.1-0.20220812140450-4bc7ef589c13/pkg/time/asset.go:21:2: package embed is not in GOROOT (/usr/local/go/src/embed)                            
#0 0.812 /root/go/pkg/mod/k8s.io/client-go@v0.23.1/plugin/pkg/client/auth/exec/metrics.go:21:2: package io/fs is not in GOROOT (/usr/local/go/src/io/fs)
#0 0.815 make: *** [Makefile:77: chaosd] Error 1
------
Dockerfile:22
--------------------
  21 |     
  22 | >>> RUN --mount=type=cache,target=/root/go/pkg \
  23 | >>>     --mount=type=cache,target=/root/.cache/go-build \
  24 | >>>     --mount=type=cache,target=/src/ui/node_modules \
  25 | >>>     IMG_LDFLAGS=$LDFLAGS make binary
  26 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c IMG_LDFLAGS=$LDFLAGS make binary" did not complete successfully: exit code: 2
make: *** [Makefile:73: image-binary] Error 1
```