### PR TITLE
Fix: Set BYTEMAN_HOME environment variable when not set

### DIFF
--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -37,6 +37,7 @@ func SetRuntimeEnv() error {
 		if err != nil {
 			return err
 		}
+		bytemanHome = fmt.Sprintf("%s/tools/byteman", wd)
 	}
 
 	path := os.Getenv("PATH")


### PR DESCRIPTION
- Set the BYTEMAN_HOME environment variable to the correct path if it's not already set.
- Used fmt.Sprintf to dynamically construct the path for BYTEMAN_HOME.